### PR TITLE
build: rename Go module path to github.com/golgeek/sb

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X github.com/inpher/sb/internal/config.VERSION={{.Version}} -X github.com/inpher/sb/internal/config.COMMIT={{.Commit}}'
+    - '-s -w -X github.com/golgeek/sb/internal/config.VERSION={{.Version}} -X github.com/golgeek/sb/internal/config.COMMIT={{.Commit}}'
   goos:
     - linux
   goarch:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) <2015>
+Copyright (c) 2015-2026
     - Mathieu Bodjikian <mathieu@bodjikian.fr>
     - Ludovic Leroux <ludovic@leroux.pl>
     - Inpher Inc. <info@inpher.io>

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 <img alt="SB logo" src="./docs/assets/logo.png"><br>
 <h1 align="center">S(sh) B(astion)</h1>
 <p align="center">
-  <img alt="Test status" src="https://github.com/inpher/sb/workflows/main-tests/badge.svg">
-  <a href="http://goreportcard.com/report/inpher/sb">
+  <img alt="Test status" src="https://github.com/golgeek/sb/workflows/main-tests/badge.svg">
+  <a href="http://goreportcard.com/report/golgeek/sb">
      <img alt="Go report" src="https://img.shields.io/badge/Go_report-A+-brightgreen.svg">
   </a>
   <a href="https://opensource.org/licenses/MIT">
     <img alt="License" src="https://img.shields.io/badge/license-MIT-brightgreen.svg">
   </a>
-  <a href="https://github.com/inpher/sb/releases/latest">
-    <img alt="Release" src="https://img.shields.io/github/release/inpher/sb.svg">
+  <a href="https://github.com/golgeek/sb/releases/latest">
+    <img alt="Release" src="https://img.shields.io/github/release/golgeek/sb.svg">
   </a>
 </p>
 
@@ -87,4 +87,4 @@ Administration documentation:
 
 # License
 
-Released under the [MIT License](https://github.com/inpher/sb/blob/master/LICENSE)
+Released under the [MIT License](https://github.com/golgeek/sb/blob/master/LICENSE)

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 	"github.com/mholt/archiver/v4"
 	"github.com/pkg/errors"
 )

--- a/cmd/createAccount.go
+++ b/cmd/createAccount.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // CreateAccount describes the command

--- a/cmd/createGroup.go
+++ b/cmd/createGroup.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 
 	"golang.org/x/term"
 )

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/ReneKroon/ttlcache"
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/replicationqueue"
-	"github.com/inpher/sb/internal/types"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/replicationqueue"
+	"github.com/golgeek/sb/internal/types"
 )
 
 // CreateAccount describes the command

--- a/cmd/delAccount.go
+++ b/cmd/delAccount.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // DelAccount describes the command

--- a/cmd/delGroup.go
+++ b/cmd/delGroup.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // DelGroup describes the command

--- a/cmd/groupAddACLKeeper.go
+++ b/cmd/groupAddACLKeeper.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupAddACLKeeper describes the command

--- a/cmd/groupAddAccess.go
+++ b/cmd/groupAddAccess.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupAddAccess describes the help command

--- a/cmd/groupAddGateKeeper.go
+++ b/cmd/groupAddGateKeeper.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupAddGateKeeper describes the command

--- a/cmd/groupAddMember.go
+++ b/cmd/groupAddMember.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupAddMember describes the command

--- a/cmd/groupAddOwner.go
+++ b/cmd/groupAddOwner.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupAddOwner describes the command

--- a/cmd/groupDelACLKeeper.go
+++ b/cmd/groupDelACLKeeper.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupDelACLKeeper describes the command

--- a/cmd/groupDelAccess.go
+++ b/cmd/groupDelAccess.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupDelAccess describes the help command

--- a/cmd/groupDelGateKeeper.go
+++ b/cmd/groupDelGateKeeper.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupDelGateKeeper describes the command

--- a/cmd/groupDelMember.go
+++ b/cmd/groupDelMember.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupDelMember describes the command

--- a/cmd/groupDelOwner.go
+++ b/cmd/groupDelOwner.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupDelOwner describes the command

--- a/cmd/groupGenerateEgressKey.go
+++ b/cmd/groupGenerateEgressKey.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 
 	"golang.org/x/term"
 )

--- a/cmd/groupInfo.go
+++ b/cmd/groupInfo.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupInfo describes the help command

--- a/cmd/groupList.go
+++ b/cmd/groupList.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupList describes the help command

--- a/cmd/groupListAccesses.go
+++ b/cmd/groupListAccesses.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // GroupListAccesses describes the help command

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -5,10 +5,10 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // Help describes the help command

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // Info describes the info command

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/types"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/types"
 
 	prompt "github.com/c-bata/go-prompt"
 )

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 	"github.com/mholt/archiver/v4"
 	"github.com/pkg/errors"
 )

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,10 +8,10 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/types"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/types"
 
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 
 	"golang.org/x/term"
 )

--- a/cmd/selfAddAccess.go
+++ b/cmd/selfAddAccess.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfAddAccess describes the help command

--- a/cmd/selfAddIngressKey.go
+++ b/cmd/selfAddIngressKey.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfAddIngressKey describes the selfAddIngresKey command

--- a/cmd/selfDelAccess.go
+++ b/cmd/selfDelAccess.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfDelAccess describes the help command

--- a/cmd/selfDelIngressKey.go
+++ b/cmd/selfDelIngressKey.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 
 	"golang.org/x/crypto/ssh"
 )

--- a/cmd/selfDisableTOTP.go
+++ b/cmd/selfDisableTOTP.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 
 	"github.com/fatih/color"
 )

--- a/cmd/selfEnableTOTP.go
+++ b/cmd/selfEnableTOTP.go
@@ -7,10 +7,10 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 
 	"github.com/fatih/color"
 	"github.com/mdp/qrterminal/v3"

--- a/cmd/selfForgetHostkey.go
+++ b/cmd/selfForgetHostkey.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfForgetHostkey describes the SelfForgetHostkey command

--- a/cmd/selfGenerateEgressKey.go
+++ b/cmd/selfGenerateEgressKey.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 
 	"golang.org/x/term"
 )

--- a/cmd/selfGenerateTOTPCodes.go
+++ b/cmd/selfGenerateTOTPCodes.go
@@ -5,9 +5,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfGenerateTOTPCodes describes the SelfGenerateTOTPCodes command

--- a/cmd/selfGetSessionAsGif.go
+++ b/cmd/selfGetSessionAsGif.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/storage"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/storage"
 	"github.com/pkg/errors"
 
 	"github.com/golgeek/ttyrec2gif"

--- a/cmd/selfListAccesses.go
+++ b/cmd/selfListAccesses.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfListAccesses describes the selfListAccesses command

--- a/cmd/selfListEgressKeys.go
+++ b/cmd/selfListEgressKeys.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfListEgressKeys describes the selfListEgressKeys command

--- a/cmd/selfListIngressKeys.go
+++ b/cmd/selfListIngressKeys.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfListIngressKeys describes the selfListIngressKeys command

--- a/cmd/selfListSessions.go
+++ b/cmd/selfListSessions.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // SelfListSessions describes the selfListAccesses command

--- a/cmd/selfPlaySession.go
+++ b/cmd/selfPlaySession.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/storage"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/storage"
 	"github.com/pkg/errors"
 	"maze.io/x/ttyrec"
 )

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 	"github.com/pkg/errors"
 )
 

--- a/cmd/ttyrec.go
+++ b/cmd/ttyrec.go
@@ -10,11 +10,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/storage"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/storage"
 	"github.com/pkg/errors"
 	"maze.io/x/ttyrec"
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/inpher/sb
+module github.com/golgeek/sb
 
 go 1.21
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/types"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/types"
 )
 
 var (

--- a/internal/commands/types.go
+++ b/internal/commands/types.go
@@ -1,8 +1,8 @@
 package commands
 
 import (
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
 )
 
 // Command descibes the required functions of a sb command interface

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/inpher/sb/internal/types"
+	"github.com/golgeek/sb/internal/types"
 	"github.com/spf13/viper"
 )
 

--- a/internal/helpers/system.go
+++ b/internal/helpers/system.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inpher/sb/internal/config"
+	"github.com/golgeek/sb/internal/config"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )

--- a/internal/models/access.go
+++ b/internal/models/access.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/inpher/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/helpers"
 
 	"github.com/fatih/color"
 	"gorm.io/gorm"

--- a/internal/models/group.go
+++ b/internal/models/group.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/inpher/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/helpers"
 
 	"github.com/fatih/color"
 	"golang.org/x/crypto/ssh"

--- a/internal/models/group_test.go
+++ b/internal/models/group_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/inpher/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/helpers"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"

--- a/internal/models/log.go
+++ b/internal/models/log.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
 	"github.com/pkg/errors"
 
 	"github.com/glebarez/sqlite" // Blank import

--- a/internal/models/log_test.go
+++ b/internal/models/log_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/inpher/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/helpers"
 
 	"github.com/stretchr/testify/require"
 )

--- a/internal/models/replication.go
+++ b/internal/models/replication.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
 	"github.com/pkg/errors"
 
 	"github.com/fatih/color"

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/inpher/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/helpers"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"

--- a/internal/replicationqueue/googlepubsub/pubsub.go
+++ b/internal/replicationqueue/googlepubsub/pubsub.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/inpher/sb/internal/models"
+	"github.com/golgeek/sb/internal/models"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )

--- a/internal/replicationqueue/replicationQueue.go
+++ b/internal/replicationqueue/replicationQueue.go
@@ -3,9 +3,9 @@ package replicationqueue
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/replicationqueue/googlepubsub"
-	"github.com/inpher/sb/internal/types"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/replicationqueue/googlepubsub"
+	"github.com/golgeek/sb/internal/types"
 	"github.com/pkg/errors"
 )
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -3,9 +3,9 @@ package storage
 import (
 	"fmt"
 
-	"github.com/inpher/sb/internal/storage/gcs"
-	"github.com/inpher/sb/internal/storage/s3"
-	"github.com/inpher/sb/internal/types"
+	"github.com/golgeek/sb/internal/storage/gcs"
+	"github.com/golgeek/sb/internal/storage/s3"
+	"github.com/golgeek/sb/internal/types"
 	"github.com/pkg/errors"
 )
 

--- a/main.go
+++ b/main.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inpher/sb/cmd"
-	"github.com/inpher/sb/internal/commands"
-	"github.com/inpher/sb/internal/config"
-	"github.com/inpher/sb/internal/helpers"
-	"github.com/inpher/sb/internal/models"
-	"github.com/inpher/sb/internal/types"
+	"github.com/golgeek/sb/cmd"
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/config"
+	"github.com/golgeek/sb/internal/helpers"
+	"github.com/golgeek/sb/internal/models"
+	"github.com/golgeek/sb/internal/types"
 )
 
 // Run gocyclo


### PR DESCRIPTION
## Summary

The repository has been transferred to `github.com/golgeek/sb`. This makes the
codebase's canonical module path match its new home.

## Previous behavior

The module was published as `github.com/inpher/sb`, and every import path, the
`.goreleaser.yml` ldflags, and the README badges/links pointed at the old path.

## Why it was a problem

A module whose canonical path doesn't match its repository home breaks
`go get github.com/golgeek/sb` reproducibility, confuses tooling, and leaves the
goreleaser version-injection symbol path
(`-X github.com/inpher/sb/internal/config.VERSION`) unresolved at release time.

## What changed

- `go.mod` module directive and **every import path** across the codebase
  (59 `.go` files): `github.com/inpher/sb` → `github.com/golgeek/sb`.
- `.goreleaser.yml` ldflags and the `README.md` badges/links (including the Go
  Report Card report URL) updated to the new repo path.
- `LICENSE` copyright-year placeholder filled in (`<2015>` → `2015-2026`); the
  existing copyright holders are preserved, as MIT requires their notices to be
  retained.
- Company-identity references that are **not** the repo path (`inpher.io`
  emails, docs prose) are intentionally left unchanged.

No behavioral code changed — this is a pure path rename.

## How it's tested

- `go build ./...` — clean.

## Reviewer checklist

- [x] `git grep inpher/sb` returns nothing.
- [x] `go build ./...` passes.

> **Note:** `internal/models` tests still hit the pre-existing non-hermetic
> `net.LookupIP()` failure inherited from `main` (documented in `CLAUDE.md`);
> that is a separate, pre-existing issue addressed independently.