### PR TITLE
totp: generate recovery codes with a cryptographically secure RNG

### DIFF
--- a/cmd/selfEnableTOTP.go
+++ b/cmd/selfEnableTOTP.go
@@ -53,8 +53,14 @@ func (c *SelfEnableTOTP) Execute(ct *commands.Context) (repl models.ReplicationD
 		return
 	}
 
-	// Generate the random emergency codes
-	randomCodes := helpers.GetRandomStrings(5, 8)
+	// Generate the random emergency codes from a cryptographically secure
+	// source. These codes bypass TOTP, so if the secure RNG fails we must abort
+	// rather than enable 2FA with predictable or empty recovery codes.
+	randomCodes, err := helpers.GetRandomStrings(5, 8)
+	if err != nil {
+		err = fmt.Errorf("failed to generate TOTP emergency codes: %w", err)
+		return
+	}
 
 	// Generate the TOTP secret
 	key, err := totp.Generate(totp.GenerateOpts{

--- a/cmd/selfGenerateTOTPCodes.go
+++ b/cmd/selfGenerateTOTPCodes.go
@@ -47,7 +47,14 @@ func (c *SelfGenerateTOTPCodes) Execute(ct *commands.Context) (repl models.Repli
 
 	_, currentSecret, _ := ct.User.GetTOTP()
 
-	random := helpers.GetRandomStrings(5, 8)
+	// Generate fresh emergency codes from a cryptographically secure source.
+	// These codes bypass TOTP, so a secure-RNG failure must abort rather than
+	// overwrite the user's recovery codes with predictable or empty ones.
+	random, err := helpers.GetRandomStrings(5, 8)
+	if err != nil {
+		err = fmt.Errorf("failed to generate TOTP emergency codes: %w", err)
+		return
+	}
 
 	repl = models.ReplicationData{
 		"account":      ct.User.User.Username,

--- a/internal/helpers/getRandomStrings_test.go
+++ b/internal/helpers/getRandomStrings_test.go
@@ -1,0 +1,71 @@
+package helpers
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// failingReader is an io.Reader that always fails. It stands in for a broken
+// system entropy source so we can assert that random-string generation fails
+// closed instead of emitting predictable or empty codes.
+type failingReader struct{}
+
+func (failingReader) Read(p []byte) (int, error) {
+	return 0, errors.New("entropy source unavailable")
+}
+
+// TestGetRandomStrings_ShapeAndAlphabet exercises the production entry point
+// (backed by crypto/rand) and checks the contract the TOTP scratch codes depend
+// on: the right number of strings, each of the requested length, containing only
+// decimal digits (so pam_google_authenticator can validate them).
+func TestGetRandomStrings_ShapeAndAlphabet(t *testing.T) {
+	const quantity, length = 5, 8
+
+	got, err := GetRandomStrings(quantity, length)
+	require.NoError(t, err, "generating codes from the real secure source should not fail")
+	require.Len(t, got, quantity, "unexpected number of generated codes")
+
+	for _, code := range got {
+		require.Len(t, code, length, "code %q has the wrong length", code)
+		for _, r := range code {
+			require.True(t, r >= '0' && r <= '9', "code %q contains non-digit %q", code, r)
+		}
+	}
+}
+
+// TestGetRandomStrings_DeterministicFromReader proves the generator draws its
+// randomness from the injected reader (not a hidden global) by feeding a fully
+// deterministic byte stream and asserting the exact mapping to digits.
+//
+// crypto/rand.Int reads one byte per digit for an upper bound of 10 and masks it
+// to the low nibble: a stream of 0x00 bytes maps every digit to '0', and a
+// stream of 0x09 bytes maps every digit to '9' (0x09 & 0x0f = 9, which is < 10
+// and therefore accepted without rejection).
+func TestGetRandomStrings_DeterministicFromReader(t *testing.T) {
+	zeros := getRandomStringsMust(t, bytes.Repeat([]byte{0x00}, 64), 2, 4)
+	require.Equal(t, []string{"0000", "0000"}, zeros, "all-zero entropy should yield all '0' digits")
+
+	nines := getRandomStringsMust(t, bytes.Repeat([]byte{0x09}, 64), 1, 5)
+	require.Equal(t, []string{"99999"}, nines, "all-0x09 entropy should yield all '9' digits")
+}
+
+// TestGetRandomStrings_FailsClosed asserts that a read error from the entropy
+// source aborts generation: the function returns an error and no partial output,
+// so a caller can never enable 2FA with weak or empty recovery codes.
+func TestGetRandomStrings_FailsClosed(t *testing.T) {
+	got, err := getRandomStrings(failingReader{}, 5, 8)
+	require.Error(t, err, "a failing entropy source must produce an error")
+	require.Nil(t, got, "no codes should be returned when the entropy source fails")
+}
+
+// getRandomStringsMust is a test helper that runs the injectable core against a
+// fixed byte stream and fails the test on any error.
+func getRandomStringsMust(t *testing.T, stream []byte, quantity, length int) []string {
+	t.Helper()
+	got, err := getRandomStrings(bytes.NewReader(stream), quantity, length)
+	require.NoError(t, err)
+	return got
+}

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -8,10 +8,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/big"
 	"os"
 	"strings"
-	"time"
 )
 
 // Helper describes the basic properties of a sb Helper type
@@ -347,22 +346,61 @@ func ParseCommandLine(cmd string) ([]string, error) {
 	return args, nil
 }
 
-// GetRandomStrings returns x random strings of y characters
-func GetRandomStrings(quantity int, length int) (rdm []string) {
+// GetRandomStrings returns `quantity` random strings, each `length` decimal
+// digits long, drawn from a cryptographically secure random source
+// (crypto/rand).
+//
+// This generator is security-sensitive: it produces the TOTP emergency/recovery
+// "scratch" codes written to each user's ~/.google_authenticator file (see
+// cmd/selfEnableTOTP.go and cmd/selfGenerateTOTPCodes.go). Those codes bypass
+// the TOTP second factor, so they must be unpredictable. A previous version used
+// math/rand seeded with time.Now().UnixNano(), which made the codes recoverable
+// by an attacker able to approximate the generation time; crypto/rand removes
+// that weakness entirely.
+//
+// The alphabet is deliberately restricted to decimal digits and the length is
+// left to the caller because pam_google_authenticator validates scratch codes as
+// plaintext 8-digit decimal numbers. Widening the alphabet (e.g. base32),
+// changing the length, or hashing the stored codes would make the PAM module
+// reject them and silently break 2FA recovery, so those hardenings are not
+// applied here.
+//
+// It returns an error if the system's secure random source cannot be read.
+// Callers MUST fail closed on that error and never fall back to a weaker source
+// or emit empty/partial codes.
+func GetRandomStrings(quantity int, length int) (rdm []string, err error) {
+	return getRandomStrings(cryptorand.Reader, quantity, length)
+}
 
-	rand.Seed(time.Now().UnixNano())
-	letterRunes := []rune("0123456789")
+// getRandomStrings is the testable core of GetRandomStrings. It reads its
+// randomness from the provided reader so unit tests can inject a deterministic
+// or deliberately failing source instead of the process-wide
+// crypto/rand.Reader. Production callers go through GetRandomStrings, which wires
+// in crypto/rand.Reader.
+func getRandomStrings(reader io.Reader, quantity int, length int) (rdm []string, err error) {
+
+	const digits = "0123456789"
+
+	rdm = make([]string, 0, quantity)
 
 	for i := 0; i < quantity; i++ {
 
-		b := make([]rune, length)
+		b := make([]byte, length)
 		for j := range b {
-			b[j] = letterRunes[rand.Intn(len(letterRunes))]
+			// cryptorand.Int returns a uniformly distributed value in
+			// [0, len(digits)) with no modulo bias, reading entropy from
+			// `reader`. Any read failure is propagated so the caller can fail
+			// closed rather than emit a predictable or truncated code.
+			n, ierr := cryptorand.Int(reader, big.NewInt(int64(len(digits))))
+			if ierr != nil {
+				return nil, fmt.Errorf("reading from secure random source: %w", ierr)
+			}
+			b[j] = digits[n.Int64()]
 		}
 		rdm = append(rdm, string(b))
 	}
 
-	return
+	return rdm, nil
 }
 
 func GetHostname() (hostname string, err error) {

--- a/internal/helpers/system.go
+++ b/internal/helpers/system.go
@@ -398,8 +398,19 @@ func RemoveHostKey(username, knownHostsFilePath, hostkey string) (err error) {
 
 func GenerateNewEgressKey(algo string, size string, passphrase string, username string) (privateKey, publicKey, privateKeyFilePath, publicKeyFilePath, filesOwner string, err error) {
 
-	keyComment := fmt.Sprintf("%s@sb:%s:%d", username, GetRandomStrings(1, 5)[0], time.Now().Unix())
-	privateKeyFilePath = fmt.Sprintf("/home/%s/.ssh/id_%s_%s_private.%s_%d", username, algo, size, GetRandomStrings(1, 5)[0], time.Now().Unix())
+	// Two short random suffixes keep the key comment and the on-disk key
+	// filename unique. They are not secrets, but they share the now
+	// cryptographically secure generator, which can fail to read the system
+	// entropy source; if it does we abort rather than build paths from an empty
+	// or weak suffix.
+	suffixes, err := GetRandomStrings(2, 5)
+	if err != nil {
+		err = errors.Wrap(err, "Unable to generate random key suffixes")
+		return
+	}
+
+	keyComment := fmt.Sprintf("%s@sb:%s:%d", username, suffixes[0], time.Now().Unix())
+	privateKeyFilePath = fmt.Sprintf("/home/%s/.ssh/id_%s_%s_private.%s_%d", username, algo, size, suffixes[1], time.Now().Unix())
 	publicKeyFilePath = fmt.Sprintf("%s.pub", privateKeyFilePath)
 	filesOwner = username
 


### PR DESCRIPTION
## Summary

TOTP recovery (scratch) codes are now drawn from a cryptographically secure RNG
instead of a time-seeded non-cryptographic one.

## Previous behavior

`helpers.GetRandomStrings` generated the TOTP recovery codes using `math/rand`
seeded from the current time.

## Why it was a problem

An attacker who could estimate when the codes were generated could narrow the
RNG state and predict the recovery codes — these codes bypass the second factor,
so this is a real 2FA-bypass risk. (MODERNIZATION.md §1.1.)

## What changed

- `helpers.GetRandomStrings` now draws from `crypto/rand` via `crypto/rand.Int`,
  giving a uniform, unbiased distribution with no modulo bias.
- It now returns an `error` so callers **fail closed** if the system RNG is
  unavailable, rather than silently emitting weak codes.
- Codes remain 8-digit decimal and stored as-is **on purpose**:
  `pam_google_authenticator` owns scratch-code validation and rejects
  hashed/base32/wider codes, so the "hash + widen" idea in MODERNIZATION.md is
  intentionally not applied here.

## How it's tested

- Unit tests cover the new RNG path (uniform digits, correct length/count, and
  the fail-closed error behavior).
- `go build ./...` and `go test ./...` — clean.

## Reviewer checklist

- [ ] No remaining use of `math/rand` for security-sensitive values.
- [ ] Callers handle the new returned error (fail closed).