### PR TITLE
ci: fix main-tests e2e and modernize its actions

### DIFF
--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: '1.21'
     - name: Run tests
       run: go test ./...
 
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: '1.21'
     - name: Run gocyclo
       run: go generate ./...
 
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Build the e2e tests stack
-      run: (cd demo && docker-compose up -d)
+      run: (cd demo && docker compose up -d)
     - name: e2e tests
       run: sleep 5; bash ./tests/e2e.sh


### PR DESCRIPTION
## Summary

Fixes the `main-tests` workflow (runs on push to `main`), whose `e2e` job was
failing on every push.

## Previous behavior

`main-tests.yml` invoked the e2e stack with `docker-compose` (Compose v1) and
used the deprecated `actions/checkout@v2` / `actions/setup-go@v2`.

## Why it was a problem

GitHub-hosted runners no longer ship the standalone `docker-compose` binary, so
the `e2e` job failed with `docker-compose: command not found` on every push to
`main`. The v2 actions also run on an end-of-life Node runtime and emit
deprecation warnings.

## What changed

- `e2e` step: `docker-compose` → `docker compose` (Compose v2).
- `actions/checkout@v2` → `@v4`, `actions/setup-go@v2` → `@v5`, and quoted
  `go-version: '1.21'` — matching the already-modernized `pr.yml` so both CI
  workflows stay consistent.

This is the same `e2e` fix previously applied to the PR workflow, now applied to
the push/`main` workflow.

## How it's tested

- The change is confined to a single workflow file; it'll be confirmed green by
  the `main-tests / e2e` run on the next push to `main` (i.e. when this merges).

## Reviewer checklist

- [ ] No `docker-compose` (v1) invocation remains in `.github/workflows/`.
- [ ] `main-tests / e2e` passes after merge.