### PR TITLE
build: add a Makefile + local e2e runner, and modernize releases for GoReleaser v2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Build-context excludes for the demo images (compose build context is the repo
+# root, so Docker reads this file from here). Keep the context limited to what
+# `go build` actually needs (module source + demo/assets), and drop the VCS
+# history, local build artifacts, runtime databases, and editor/tooling cruft so
+# the context stays small and image-layer caching is not invalidated by unrelated
+# local file churn.
+.git
+.github
+.claude
+.golangci.yaml
+.goreleaser.yml
+
+# Host build artifacts (see Makefile) — the image compiles its own binary.
+/bin/
+/sb
+
+# Local runtime state, never wanted in an image.
+*.db
+
+# OS / editor noise.
+.DS_Store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,24 +9,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
-    - name: Unshallow
-      run: git fetch --prune --unshallow
+      uses: actions/checkout@v4
+      with:
+        # GoReleaser needs the full commit history and all tags to derive the
+        # version; a full checkout replaces the old manual `git fetch --unshallow`.
+        fetch-depth: 0
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: '1.26'
     - name: Import GPG key
       id: import_gpg
-      uses: paultyng/ghaction-import-gpg@v2.1.0
-      env:
-        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        PASSPHRASE: ${{ secrets.PASSPHRASE }}
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: crazy-max/ghaction-import-gpg@v6
       with:
-        version: latest
-        args: release --rm-dist
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.PASSPHRASE }}
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v6
+      with:
+        # Pin the major version so a future GoReleaser v3 cannot silently break
+        # the release (the config is schema v2).
+        version: '~> v2'
+        args: release --clean
       env:
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /sb
+/bin/
 /logs.db
 /replication.db
 .DS_Store

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,27 +1,32 @@
+# GoReleaser configuration (schema v2). Pinned to v2 in the release workflow so a
+# future major release of GoReleaser cannot silently break the pipeline.
+version: 2
+
 before:
   hooks:
     - go mod tidy
     - go generate ./...
 
 builds:
-- env:
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X github.com/golgeek/sb/internal/config.VERSION={{.Version}} -X github.com/golgeek/sb/internal/config.COMMIT={{.Commit}}'
-  goos:
-    - linux
-  goarch:
-    - amd64
-    - '386'
-    - arm
-    - arm64
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X github.com/golgeek/sb/internal/config.VERSION={{.Version}} -X github.com/golgeek/sb/internal/config.COMMIT={{.Commit}}'
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:
-  - format: tar.gz
+  # v2 renamed the singular `format` to the list-valued `formats`.
+  - formats: [ tar.gz ]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:
@@ -40,4 +45,5 @@ signs:
       - "${artifact}"
 
 changelog:
-  skip: true
+  # v2 renamed `skip: true` to `disable: true`.
+  disable: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+# Makefile for sb — the SSH bastion / jump host.
+#
+# Common developer entry points: build the binary locally, cross-compile the
+# linux release targets, run the unit tests, and run the local end-to-end suite.
+# Run `make` (or `make help`) to see the available targets.
+
+# --- Build metadata -----------------------------------------------------------
+#
+# These mirror what goreleaser injects at release time (see .goreleaser.yml) so a
+# locally cross-compiled binary reports the same version/commit as a released
+# one. VERSION comes from the nearest git tag (falling back to the short commit
+# when no tag is reachable); COMMIT is the short hash. Both tolerate a shallow or
+# tag-less checkout without failing the build.
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+
+# Package path that holds the VERSION/COMMIT vars the ldflags below populate.
+CONFIG_PKG := github.com/golgeek/sb/internal/config
+
+# -s -w strip the symbol table and DWARF info to shrink the binary; the two -X
+# flags stamp the build metadata into the config package at link time.
+LDFLAGS := -s -w -X $(CONFIG_PKG).VERSION=$(VERSION) -X $(CONFIG_PKG).COMMIT=$(COMMIT)
+
+# Where build artifacts land: the host-platform binary and the cross-compiled
+# release binaries all go under bin/ (gitignored) so a single `make clean` clears
+# everything and the repo root stays tidy.
+BIN_DIR := bin
+
+# Cross builds are static (CGO disabled) and reproducible (-trimpath strips local
+# filesystem paths), matching the goreleaser configuration.
+GO_BUILD_FLAGS := -trimpath -ldflags '$(LDFLAGS)'
+
+.DEFAULT_GOAL := help
+
+# --- Help ---------------------------------------------------------------------
+
+.PHONY: help
+help: ## Show this help.
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# --- Build --------------------------------------------------------------------
+
+.PHONY: build
+build: ## Build the sb binary for the host platform (bin/sb).
+	go build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/sb .
+
+.PHONY: build-linux
+build-linux: build-linux-amd64 build-linux-arm64 ## Cross-compile for linux/amd64 and linux/arm64.
+
+.PHONY: build-linux-amd64
+build-linux-amd64: ## Cross-compile for linux/amd64 (bin/sb_linux_amd64).
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+		go build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/sb_linux_amd64 .
+
+.PHONY: build-linux-arm64
+build-linux-arm64: ## Cross-compile for linux/arm64 (bin/sb_linux_arm64).
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+		go build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/sb_linux_arm64 .
+
+# --- Test ---------------------------------------------------------------------
+
+.PHONY: test
+test: ## Run the unit tests.
+	go test ./...
+
+.PHONY: e2e
+e2e: ## Run the local end-to-end suite (brings up the demo stack via docker compose).
+	./tests/e2e-local.sh
+
+# --- Housekeeping -------------------------------------------------------------
+
+.PHONY: clean
+clean: ## Remove built binaries.
+	rm -rf $(BIN_DIR)
+	rm -f sb

--- a/demo/Dockerfiles/sb/Dockerfile
+++ b/demo/Dockerfiles/sb/Dockerfile
@@ -1,7 +1,17 @@
-FROM golang:1.26-bookworm as builder
+FROM golang:1.26-bookworm AS builder
 WORKDIR /app
 ADD . /app
-RUN go build -o sb
+
+# Build metadata stamped into internal/config at link time, mirroring the
+# Makefile and goreleaser so the demo binary reports a real version instead of an
+# empty string. The args default to dev/docker for a plain `docker build`; the
+# compose file passes through real values when available.
+ARG VERSION=dev
+ARG COMMIT=docker
+RUN go build \
+    -trimpath \
+    -ldflags "-s -w -X github.com/golgeek/sb/internal/config.VERSION=${VERSION} -X github.com/golgeek/sb/internal/config.COMMIT=${COMMIT}" \
+    -o sb
 
 FROM debian:bookworm
 

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     build:
       context: ../
       dockerfile: demo/Dockerfiles/sb/Dockerfile
+      args:
+        VERSION: ${SB_VERSION:-dev}
+        COMMIT: ${SB_COMMIT:-docker}
     volumes:
       - ${PWD}/assets/configs/sb1/sb.yml:/etc/sb/sb.yml:ro
     ports:
@@ -22,6 +25,9 @@ services:
     build:
       context: ../
       dockerfile: demo/Dockerfiles/sb/Dockerfile
+      args:
+        VERSION: ${SB_VERSION:-dev}
+        COMMIT: ${SB_COMMIT:-docker}
     volumes:
       - ${PWD}/assets/configs/sb2/sb.yml:/etc/sb/sb.yml:ro
     ports:

--- a/tests/e2e-local.sh
+++ b/tests/e2e-local.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# e2e-local.sh — one-command local runner for the end-to-end suite.
+#
+# The e2e suite is split across two working directories: the demo stack must be
+# brought up from demo/ (docker-compose.yml mounts ${PWD}/assets/...), while
+# tests/e2e.sh must run from the repo root (it references $(pwd)/demo/... and
+# SCPs ./docs). CI handles that split by hand; this script does it for you so a
+# local run is a single command, and it always tears the stack down afterwards.
+#
+# Usage:
+#   tests/e2e-local.sh              # build, up, wait, test, then down
+#   KEEP_STACK=1 tests/e2e-local.sh # leave the stack running for debugging
+#   NO_BUILD=1   tests/e2e-local.sh # skip the image rebuild (faster reruns)
+#
+# Exit code is the e2e suite's own exit code; teardown never masks it.
+
+set -euo pipefail
+
+# Resolve the repo root from this script's own location so the script works no
+# matter where it is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEMO_DIR="${REPO_ROOT}/demo"
+
+# The two bastions the suite talks to (host TCP ports published by the stack).
+SB1_PORT=22001
+SB2_PORT=22002
+
+# How long to wait for the bastions' SSH ports to start accepting connections
+# before giving up (seconds).
+WAIT_TIMEOUT=120
+
+# tcp_open <port> — return success if a TCP connection to 127.0.0.1:<port>
+# succeeds. Uses bash's /dev/tcp so we don't depend on nc(1) being installed.
+tcp_open() {
+    local port="$1"
+    # The subshell + redirect either connects or fails; suppress its output.
+    (exec 3<>"/dev/tcp/127.0.0.1/${port}") 2>/dev/null
+}
+
+# wait_for_port <port> — block until the port accepts connections or we hit the
+# timeout. Fails closed (non-zero) so the caller can abort the run.
+wait_for_port() {
+    local port="$1"
+    local waited=0
+    until tcp_open "${port}"; do
+        if (( waited >= WAIT_TIMEOUT )); then
+            echo "Timed out after ${WAIT_TIMEOUT}s waiting for 127.0.0.1:${port}" >&2
+            return 1
+        fi
+        sleep 2
+        (( waited += 2 ))
+    done
+}
+
+# teardown — bring the stack down unless the user asked to keep it. Registered
+# as an EXIT trap so it runs on success, failure, or interrupt. It preserves the
+# script's exit status: we capture $? first and re-exit with it at the end.
+teardown() {
+    local status=$?
+    if [[ "${KEEP_STACK:-0}" == "1" ]]; then
+        echo "KEEP_STACK=1 set — leaving the demo stack running."
+        echo "Tear it down later with: (cd '${DEMO_DIR}' && docker compose down)"
+    else
+        echo "Tearing down the demo stack..."
+        # Best-effort: don't let a teardown hiccup overwrite the real status.
+        (cd "${DEMO_DIR}" && docker compose down) || true
+    fi
+    exit "${status}"
+}
+trap teardown EXIT
+
+echo "Bringing up the demo stack (this builds images on first run)..."
+build_flag="--build"
+[[ "${NO_BUILD:-0}" == "1" ]] && build_flag=""
+# shellcheck disable=SC2086  # build_flag is intentionally word-split (may be empty).
+(cd "${DEMO_DIR}" && docker compose up -d ${build_flag})
+
+echo "Waiting for the bastions to accept SSH connections..."
+wait_for_port "${SB1_PORT}"
+wait_for_port "${SB2_PORT}"
+
+echo "Running the e2e suite..."
+# Run from the repo root, which is what tests/e2e.sh expects.
+(cd "${REPO_ROOT}" && bash ./tests/e2e.sh)


### PR DESCRIPTION
## Summary

Adds a single entry point for the common developer loop and fixes the (currently broken) release pipeline. Two cohesive commits:

1. **`build:`** a `Makefile`, a one-command local e2e runner, and version-stamping for the demo image.
2. **`ci:`** migrate the release pipeline to GoReleaser v2.

### Previously

- No documented way to build, cross-compile, test, or run the e2e suite — all ad-hoc commands. The e2e suite is awkward because it is split across two working directories (the demo stack comes up from `demo/`, but `tests/e2e.sh` must run from the repo root).
- The demo Docker image compiled `sb` with no `-ldflags`, so every demo/e2e binary reported an empty version and commit; there was no `.dockerignore`, so the entire repo (git history, host-built binaries, local `*.db` state) was sent into the build context.
- `.goreleaser.yml` used the v1 schema and `release.yml` invoked the action with `version: latest` + `args: release --rm-dist`.

### Why it was a problem

- The undocumented workflow made the project harder to contribute to and easy to get subtly wrong; an unstamped binary is hard to identify when debugging a running stack.
- `version: latest` now resolves to **GoReleaser v2**, which requires `version: 2`, rejects the renamed keys, and removed `--rm-dist` (now `--clean`). The next tagged release would have failed. The workflow actions were also several majors behind and used the now-archived `paultyng/ghaction-import-gpg`.

### What changed

**Build / dev workflow**
- `Makefile` with `build` (→ `bin/sb`), `build-linux` and per-arch `build-linux-amd64` / `build-linux-arm64` (→ `bin/sb_linux_<arch>`), `test`, `e2e`, plus a self-documenting default `help` and a `clean`. Cross-build targets mirror GoReleaser (CGO disabled, `-trimpath`, `-X …config.VERSION/COMMIT` from `git describe` / `rev-parse`) so a locally built linux binary matches a released one. All output lands under `bin/` (gitignored).
- `tests/e2e-local.sh`: brings the demo stack up, waits for both bastions' SSH ports, runs `tests/e2e.sh` from the repo root, and always tears the stack down (`KEEP_STACK` / `NO_BUILD` escape hatches).
- The demo image now stamps `VERSION`/`COMMIT` via build args (default `dev`/`docker`, passed through from compose via `SB_VERSION`/`SB_COMMIT`) and builds with `-trimpath`; added a `.dockerignore` to trim the build context.

**Release pipeline (GoReleaser v2)**
- `.goreleaser.yml` → schema v2 (`version: 2`, `archives.formats: [tar.gz]`, `changelog.disable`); build/archive/checksum/signing behavior otherwise unchanged.
- `release.yml` → `checkout@v4` (`fetch-depth: 0`, replacing the manual unshallow step), `setup-go@v5`, `crazy-max/ghaction-import-gpg@v6`, `goreleaser-action@v6` invoked as `release --clean`, pinned to `~> v2` so a future v3 can't silently break it. Trigger intentionally left as `on: release: types: [created]`.

### How it's tested

- `make build` / `make build-linux` produce correct host + linux amd64/arm64 static binaries with the version stamped.
- `go build ./...` and `go test ./...` are green at **each** commit.
- A builder-stage Docker build confirms `.dockerignore` does not starve the build and that `VERSION`/`COMMIT` land in the compiled binary.
- `goreleaser check` on v2.16.0 validates the config with no deprecation warnings; `goreleaser build --snapshot` produced a stamped binary successfully.

### Test plan for reviewer

- [ ] `make help` lists the targets; `make build` writes `bin/sb`.
- [ ] `make build-linux` writes `bin/sb_linux_amd64` and `bin/sb_linux_arm64` (both `linux`, statically linked).
- [ ] `make test` is green.
- [ ] `make e2e` brings the stack up, runs the suite, and tears it down.
- [ ] CI `tests` workflow passes; the release workflow is exercised on the next tagged release.