### PR TITLE
helpers: validate user and group names before privileged exec

### DIFF
--- a/cmd/createAccount.go
+++ b/cmd/createAccount.go
@@ -37,6 +37,14 @@ func init() {
 // Checks checks whether or not the user can execute this method
 func (c *CreateAccount) Checks(ct *commands.Context) error {
 
+	// Validate the requested username up front so a malformed name is rejected
+	// with a clear message before any system change is attempted. The same
+	// validation is enforced again deeper in helpers.AddUser as the fail-closed
+	// security boundary.
+	if err := helpers.ValidateSystemName(ct.FormattedArguments["username"]); err != nil {
+		return err
+	}
+
 	// We check the user doesn't exist yet
 	_, err := models.LoadUser(ct.FormattedArguments["username"])
 	if err == nil {

--- a/cmd/createGroup.go
+++ b/cmd/createGroup.go
@@ -55,6 +55,14 @@ func init() {
 // Checks checks whether or not the user can execute this method
 func (c *CreateGroup) Checks(ct *commands.Context) (err error) {
 
+	// Validate the requested group name up front so a malformed name is rejected
+	// with a clear message before any system change is attempted. The same
+	// validation is enforced again deeper in helpers.AddGroup as the fail-closed
+	// security boundary.
+	if err = helpers.ValidateSystemName(ct.FormattedArguments["name"]); err != nil {
+		return
+	}
+
 	// Check if the chosen group name is available
 	groups, err := models.GetAllSBGroups()
 	if err != nil {

--- a/internal/helpers/system.go
+++ b/internal/helpers/system.go
@@ -29,6 +29,13 @@ var (
 // AddAccountInGroup adds an account in a group's membership group
 func AddAccountInGroup(groupName string, account string, membershipType string) (err error) {
 
+	// Fail closed on the privilege boundary: both names are passed to usermod, so
+	// reject anything that could be parsed as a flag or break the group list
+	// before we shell out.
+	if err = ValidateSystemNames(groupName, account); err != nil {
+		return
+	}
+
 	// Build the true groupname and all the groups names
 	if !strings.HasPrefix(groupName, "bg_") {
 		groupName = fmt.Sprintf("bg_%s", groupName)
@@ -62,6 +69,14 @@ func AddGroup(groupname string, ownerAccount string) (err error) {
 	//    - adding a /etc/sudoers.d template for the group
 	//    - putting ownerAccount in all the created groups
 	//    - create the skelleton of the home folder
+
+	// Fail closed on the privilege boundary: the group name flows into addgroup,
+	// adduser, usermod, the comma-separated -G list and the /etc/sudoers.d/<group>
+	// path, and the owner account flows into usermod, so both must be validated
+	// before we shell out.
+	if err = ValidateSystemNames(groupname, ownerAccount); err != nil {
+		return
+	}
 
 	// Build the true groupname and all the groups names
 	if !strings.HasPrefix(groupname, "bg_") {
@@ -115,6 +130,15 @@ func AddGroup(groupname string, ownerAccount string) (err error) {
 
 // AddUser creates a new user on the system
 func AddUser(homedir, username, shellPath string) (err error) {
+
+	// Fail closed on the privilege boundary: the username is passed to adduser and
+	// usermod, so reject anything that could be parsed as a flag before we shell
+	// out. homedir and shellPath are sb-derived, not user-supplied, so they are
+	// not validated here.
+	if err = ValidateSystemName(username); err != nil {
+		return
+	}
+
 	commands := make([][]string, 0, 2)
 
 	// Calling adduser
@@ -193,6 +217,13 @@ func CreateHomeSkeleton(homedir string, username string, homeType string) (err e
 // DeleteAccount deletes a group from the system
 func DeleteAccount(username, archiveSuffix string) (err error) {
 
+	// Fail closed on the privilege boundary: the username is passed to usermod and
+	// groupmod, so validate it before we shell out. The archive suffix is
+	// generated internally (bak_<timestamp>) and is not user-supplied.
+	if err = ValidateSystemName(username); err != nil {
+		return
+	}
+
 	// Build the command to archive the user
 	commands := [][]string{
 		{
@@ -231,6 +262,14 @@ func DeleteGroup(groupname, archiveSuffix string) (err error) {
 	//    - deleting the user for the group as bg_GROUPNAME
 	//    - removing a /etc/sudoers.d template for the group
 	//    - moving the home folder
+
+	// Fail closed on the privilege boundary: the group name is passed to usermod,
+	// groupmod and the /etc/sudoers.d/<group> path, so validate it before we shell
+	// out. The archive suffix is generated internally (bak_<timestamp>) and is not
+	// user-supplied.
+	if err = ValidateSystemName(groupname); err != nil {
+		return
+	}
 
 	// Build the true groupname and all the groups names
 	if !strings.HasPrefix(groupname, "bg_") {
@@ -573,6 +612,12 @@ func ArchiveHomeSkelleton(homedir, suffix string) (err error) {
 
 // RemoveAccountFromGroup adds an account in a group's membership group
 func RemoveAccountFromGroup(groupName string, account string, membershipType string) (err error) {
+
+	// Fail closed on the privilege boundary: both names are passed to deluser, so
+	// validate them before we shell out.
+	if err = ValidateSystemNames(groupName, account); err != nil {
+		return
+	}
 
 	// Build the true groupname and all the groups names
 	if !strings.HasPrefix(groupName, "bg_") {

--- a/internal/helpers/system_validation_test.go
+++ b/internal/helpers/system_validation_test.go
@@ -1,0 +1,68 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSystemHelpersRejectMaliciousNames verifies that every privileged helper
+// that shells out to adduser/usermod/addgroup/deluser/groupmod fails closed when
+// handed a flag-like name, BEFORE it can exec anything. These tests are hermetic
+// precisely because validation short-circuits the function: a name like "-x"
+// never reaches runCommand, so no sudo is invoked. The accepting path (a valid
+// name) is covered by TestValidateSystemName; here we only assert the rejection
+// reaches each entry point.
+func TestSystemHelpersRejectMaliciousNames(t *testing.T) {
+	const malicious = "-x" // would be parsed as a flag by the underlying tools
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "AddUser rejects flag-like username",
+			call: func() error { return AddUser("/home/x", malicious, "/usr/local/bin/sb") },
+		},
+		{
+			name: "AddGroup rejects flag-like group name",
+			call: func() error { return AddGroup(malicious, "owner") },
+		},
+		{
+			name: "AddGroup rejects flag-like owner account",
+			call: func() error { return AddGroup("team", malicious) },
+		},
+		{
+			name: "AddAccountInGroup rejects flag-like group name",
+			call: func() error { return AddAccountInGroup(malicious, "alice", "m") },
+		},
+		{
+			name: "AddAccountInGroup rejects flag-like account",
+			call: func() error { return AddAccountInGroup("team", malicious, "m") },
+		},
+		{
+			name: "RemoveAccountFromGroup rejects flag-like group name",
+			call: func() error { return RemoveAccountFromGroup(malicious, "alice", "m") },
+		},
+		{
+			name: "RemoveAccountFromGroup rejects flag-like account",
+			call: func() error { return RemoveAccountFromGroup("team", malicious, "m") },
+		},
+		{
+			name: "DeleteAccount rejects flag-like username",
+			call: func() error { return DeleteAccount(malicious, "bak_1") },
+		},
+		{
+			name: "DeleteGroup rejects flag-like group name",
+			call: func() error { return DeleteGroup(malicious, "bak_1") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			require.Error(t, err, "a flag-like name must be rejected before exec")
+			require.Contains(t, err.Error(), "invalid name", "the error should come from name validation, not from a downstream exec")
+		})
+	}
+}

--- a/internal/helpers/validate.go
+++ b/internal/helpers/validate.go
@@ -1,0 +1,81 @@
+package helpers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// systemNameRegexp constrains the Linux user and group names that sb hands to
+// the privileged useradd/usermod/addgroup/deluser/groupmod tools.
+//
+// The pattern requires a name to start with a lowercase ASCII letter and to
+// contain only lowercase letters, digits, underscores and hyphens, for a total
+// length of 1 to 31 characters. Two properties matter for the security boundary:
+//
+//   - Because the first character must be a letter, a name can never begin with
+//     '-'. A leading '-' is what makes ARGUMENT INJECTION possible: a name like
+//     "-x" or "--shell" would otherwise be parsed by adduser/usermod as a flag
+//     instead of as the operand sb intends.
+//   - Because the body excludes ',', '/', '.', ':' and whitespace, a name can
+//     neither split the comma-separated group lists that system.go builds (e.g.
+//     usermod -G bg_x-o,bg_x-gk,...) nor disturb the "/etc/sudoers.d/<group>"
+//     path and the sudoers glob assumptions that encode sb's privilege model.
+//
+// It is deliberately stricter than Linux's own NAME_REGEX (which also allows a
+// leading underscore and a trailing '$'): sb never needs those forms, and every
+// character class we drop is one fewer thing the security boundary must reason
+// about.
+var systemNameRegexp = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,30}$`)
+
+// reservedGroupPrefix is the prefix sb reserves for the system groups and group
+// users it creates internally (bg_GROUP, bg_GROUP-o, bg_GROUP-gk, bg_GROUP-aclk
+// and the bg_GROUP login user). A user-supplied name must not collide with that
+// namespace, so it may not start with this prefix.
+const reservedGroupPrefix = "bg_"
+
+// reservedSystemNames lists names that satisfy systemNameRegexp but that sb must
+// still refuse to manage. "root" is rejected because operating on it through the
+// sudoers-whitelisted tools would let a caller target the superuser account.
+var reservedSystemNames = map[string]struct{}{
+	"root": {},
+}
+
+// ValidateSystemName validates a user-supplied Linux user or group name before
+// it is passed to any privileged system tool. It returns a descriptive error
+// when name is empty, malformed, reserved, or sits in sb's reserved group
+// namespace, and nil when the name is safe to use.
+//
+// This is the single choke point for the input-validation security boundary:
+// every system.go helper that shells out to
+// adduser/usermod/addgroup/deluser/groupmod runs its name arguments through this
+// function first, so a malformed name fails closed before it can reach exec — on
+// both the direct command path and the replication apply path.
+func ValidateSystemName(name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid name: must not be empty")
+	}
+	if !systemNameRegexp.MatchString(name) {
+		return fmt.Errorf("invalid name %q: must match %s (a lowercase letter followed by up to 30 lowercase letters, digits, '_' or '-')", name, systemNameRegexp.String())
+	}
+	if strings.HasPrefix(name, reservedGroupPrefix) {
+		return fmt.Errorf("invalid name %q: the %q prefix is reserved for sb-managed groups", name, reservedGroupPrefix)
+	}
+	if _, reserved := reservedSystemNames[name]; reserved {
+		return fmt.Errorf("invalid name %q: this name is reserved and cannot be managed by sb", name)
+	}
+	return nil
+}
+
+// ValidateSystemNames validates several names at once, returning the first
+// validation error encountered. It is a convenience wrapper around
+// ValidateSystemName for the helpers that accept more than one name (for
+// example a group name together with an account name).
+func ValidateSystemNames(names ...string) error {
+	for _, name := range names {
+		if err := ValidateSystemName(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/helpers/validate_test.go
+++ b/internal/helpers/validate_test.go
@@ -1,0 +1,74 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateSystemName covers the security-critical name validation that
+// guards every privileged adduser/usermod/addgroup/deluser/groupmod call. The
+// table groups the cases by intent so a regression is easy to localise: legit
+// names must pass, and every injection / namespace-collision shape must fail
+// closed.
+func TestValidateSystemName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid names: a leading lowercase letter then the allowed body.
+		{name: "simple", input: "alice", wantErr: false},
+		{name: "with digits", input: "alice2", wantErr: false},
+		{name: "with underscore", input: "build_bot", wantErr: false},
+		{name: "with internal hyphen", input: "ci-runner", wantErr: false},
+		{name: "single letter", input: "a", wantErr: false},
+		{name: "max length 31", input: "a" + strings.Repeat("b", 30), wantErr: false},
+
+		// Argument injection: a name that adduser/usermod would read as a flag.
+		{name: "leading hyphen", input: "-x", wantErr: true},
+		{name: "long option", input: "--shell", wantErr: true},
+		{name: "lone hyphen", input: "-", wantErr: true},
+
+		// Characters that would split group lists or sudoers paths.
+		{name: "comma", input: "a,b", wantErr: true},
+		{name: "slash", input: "a/b", wantErr: true},
+		{name: "dot", input: "a.b", wantErr: true},
+		{name: "colon", input: "a:b", wantErr: true},
+		{name: "space", input: "a b", wantErr: true},
+		{name: "newline", input: "a\nb", wantErr: true},
+
+		// Shape violations.
+		{name: "empty", input: "", wantErr: true},
+		{name: "leading digit", input: "2cool", wantErr: true},
+		{name: "leading underscore", input: "_svc", wantErr: true},
+		{name: "uppercase", input: "Alice", wantErr: true},
+		{name: "too long 32", input: "a" + strings.Repeat("b", 31), wantErr: true},
+
+		// Reserved names and the reserved group namespace.
+		{name: "root", input: "root", wantErr: true},
+		{name: "bg prefix", input: "bg_team", wantErr: true},
+		{name: "bg prefix exact", input: "bg_", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSystemName(tt.input)
+			if tt.wantErr {
+				require.Error(t, err, "input %q should be rejected", tt.input)
+			} else {
+				require.NoError(t, err, "input %q should be accepted", tt.input)
+			}
+		})
+	}
+}
+
+// TestValidateSystemNames asserts the multi-name wrapper rejects as soon as any
+// one name is invalid and accepts only when all names are valid.
+func TestValidateSystemNames(t *testing.T) {
+	require.NoError(t, ValidateSystemNames("alice", "team", "ci-runner"))
+	require.Error(t, ValidateSystemNames("alice", "-x"), "a single bad name must fail the batch")
+	require.Error(t, ValidateSystemNames("-x", "alice"), "order must not matter")
+	require.NoError(t, ValidateSystemNames(), "an empty batch with no names is a vacuous no-op")
+}


### PR DESCRIPTION
## Summary

Adds strict validation of user- and group-name input before it reaches the root-privileged `adduser`/`usermod`/`addgroup`/`deluser`/`groupmod` tools, closing an argument-injection hole on sb's privilege boundary.

## Previous behavior

`account create`, `group create` and the group-membership commands passed user-supplied usernames and group names straight through to the sudo-wrapped system tools without any validation of their shape.

## Why it was a problem

`exec.Command` prevents *shell* injection, but the names were never checked for shape:

- A name beginning with `-` (e.g. `-x`, `--shell`) is parsed by `adduser`/`usermod` as a **flag rather than an operand** — argument injection straight into a root-privileged invocation.
- A name containing `,`, `/`, `.` or `:` could split the comma-separated `-G` group lists built in `system.go`, or disturb the `/etc/sudoers.d/<group>` path and the sudoers glob assumptions that encode the privilege boundary.

## What changed

- New `helpers.ValidateSystemName` (+ `ValidateSystemNames` batch helper): constrains a name to `^[a-z][a-z0-9_-]{0,30}$`, rejects the reserved `bg_` group namespace, and rejects the reserved `root` account. Because the first character must be a lowercase letter, a name can never start with `-` — the property that closes the injection hole.
- Enforced as the **fail-closed security boundary** at the entry of every `system.go` helper that shells out (`AddUser`, `AddGroup`, `AddAccountInGroup`, `RemoveAccountFromGroup`, `DeleteAccount`, `DeleteGroup`), so a malformed name can never reach `exec` — on the direct command path **or** the replication apply path.
- `account create` and `group create` also validate up front, so a bad name is reported with a clear message before any system change is attempted.

Defense-in-depth by design: validation at the command layer gives good UX; validation at the helper layer guarantees the boundary holds regardless of caller.

## How it's tested

- Table-driven unit test for `ValidateSystemName`: valid names, argument-injection shapes (`-x`, `--shell`, `-`), list/path-breaking characters (`,` `/` `.` `:` space newline), length/case/leading-char rules, and reserved names (`root`, `bg_*`).
- Hermetic test asserting each privileged helper **fails closed** — returns the validation error before any `exec` — when handed a flag-like name.
- `go build ./...` and `go test ./...` pass; `golangci-lint run` reports 0 issues.

### Reviewer checklist
- [ ] Regex shape is acceptable for your deployments' naming conventions
- [ ] Reserved-name policy (`root`, `bg_` prefix) matches expectations
- [ ] No legitimate existing name shape is now rejected