### PR TITLE
models/helpers: stop swallowing errors in TOTP, key deletion and piped commands

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -47,7 +47,9 @@ func (c *Info) Execute(ct *commands.Context) (repl models.ReplicationData, cmdEr
 	if err != nil {
 		return
 	}
-	totpEnabled, _, totpEmergency := ct.User.GetTOTP()
+	// TOTP state is informational here, so a read error is reported inline rather
+	// than aborting the whole info command.
+	totpEnabled, _, totpEmergency, totpErr := ct.User.GetTOTP()
 
 	green := color.New(color.FgGreen).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
@@ -71,9 +73,12 @@ func (c *Info) Execute(ct *commands.Context) (repl models.ReplicationData, cmdEr
 		fmt.Printf("  -> as you're a member of the %s group, you have extra admin privileges\n", green("owners"))
 		fmt.Printf("  -> FYI, I'm running version %s on commit %s\n", green(config.VERSION), green(config.COMMIT))
 	}
-	if !totpEnabled {
+	switch {
+	case totpErr != nil:
+		fmt.Printf("  -> TOTP status is %s (your configuration file could not be read)\n", red("unavailable"))
+	case !totpEnabled:
 		fmt.Printf("  -> TOTP is %s on your account\n", red("disabled"))
-	} else {
+	default:
 		fmt.Printf("  -> TOTP is %s on your account\n", green("enabled"))
 		if len(totpEmergency) >= 3 {
 			fmt.Printf("  -> you have %s unused emergency codes, feel free to generate new ones if you wish\n", green(len(totpEmergency)))

--- a/cmd/selfEnableTOTP.go
+++ b/cmd/selfEnableTOTP.go
@@ -47,7 +47,12 @@ func (c *SelfEnableTOTP) Execute(ct *commands.Context) (repl models.ReplicationD
 
 	green := color.New(color.FgGreen).SprintFunc()
 
-	enabled, _, _ := ct.User.GetTOTP()
+	enabled, _, _, err := ct.User.GetTOTP()
+	if err != nil {
+		// Fail closed: if the current TOTP state cannot be read, do not risk
+		// overwriting an existing configuration with fresh secrets.
+		return
+	}
 	if enabled {
 		fmt.Printf("TOTP is already enabled on this account!")
 		return

--- a/cmd/selfGenerateTOTPCodes.go
+++ b/cmd/selfGenerateTOTPCodes.go
@@ -33,8 +33,12 @@ func (c *SelfGenerateTOTPCodes) Checks(ct *commands.Context) error {
 		return fmt.Errorf("the server is not configured for TOTP")
 	}
 
-	// Check that TOTP is enabled for current account
-	enabled, _, _ := ct.User.GetTOTP()
+	// Check that TOTP is enabled for current account. Fail closed if the state
+	// cannot be read so we never try to regenerate codes against a corrupt file.
+	enabled, _, _, err := ct.User.GetTOTP()
+	if err != nil {
+		return err
+	}
 	if !enabled {
 		return fmt.Errorf("TOTP is disabled on this account")
 	}
@@ -45,7 +49,12 @@ func (c *SelfGenerateTOTPCodes) Checks(ct *commands.Context) error {
 // Execute executes the command
 func (c *SelfGenerateTOTPCodes) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
 
-	_, currentSecret, _ := ct.User.GetTOTP()
+	// Re-read the current secret so the regenerated codes stay bound to it. Fail
+	// closed if it cannot be read rather than replicating an empty secret.
+	_, currentSecret, _, err := ct.User.GetTOTP()
+	if err != nil {
+		return
+	}
 
 	// Generate fresh emergency codes from a cryptographically secure source.
 	// These codes bypass TOTP, so a secure-RNG failure must abort rather than

--- a/internal/helpers/runpipedcommands_test.go
+++ b/internal/helpers/runpipedcommands_test.go
@@ -1,0 +1,73 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunPipedCommands exercises the piped-command runner with small, universally
+// available commands (echo/cat/true/false) so the test stays hermetic. It checks
+// both that healthy pipelines succeed and that a failure at every stage — an
+// empty argument list, a command that cannot start, the first command failing,
+// and a downstream command exiting non-zero — is surfaced as an error rather than
+// swallowed.
+func TestRunPipedCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		commands [][]string
+		wantErr  bool
+	}{
+		{
+			name:     "single successful command",
+			commands: [][]string{{"true"}},
+			wantErr:  false,
+		},
+		{
+			name:     "two-stage pipeline succeeds",
+			commands: [][]string{{"echo", "hello"}, {"cat"}},
+			wantErr:  false,
+		},
+		{
+			name:     "three-stage pipeline succeeds",
+			commands: [][]string{{"echo", "hello"}, {"cat"}, {"cat"}},
+			wantErr:  false,
+		},
+		{
+			name:     "no commands is an error",
+			commands: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "single command that fails",
+			commands: [][]string{{"false"}},
+			wantErr:  true,
+		},
+		{
+			name:     "downstream command exits non-zero",
+			commands: [][]string{{"echo", "hello"}, {"false"}},
+			wantErr:  true,
+		},
+		{
+			name:     "downstream command cannot start",
+			commands: [][]string{{"echo", "hello"}, {"/nonexistent/command/xyz"}},
+			wantErr:  true,
+		},
+		{
+			name:     "first command cannot run",
+			commands: [][]string{{"/nonexistent/command/xyz"}},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runPipedCommands(tt.commands...)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/helpers/system.go
+++ b/internal/helpers/system.go
@@ -660,42 +660,61 @@ func runCommand(command string, arguments ...string) (err error) {
 	return
 }
 
-// runPipedCommand executes two piped system commands
+// runPipedCommands runs a chain of system commands, wiring each command's stdout
+// into the next command's stdin (the equivalent of "cmd0 | cmd1 | ... | cmdN").
+// The last command's output and stderr are captured so they can be reported if
+// the pipeline fails. It returns the first error encountered while wiring,
+// starting, running or waiting on any command.
 func runPipedCommands(commands ...[]string) (err error) {
 
-	var out bytes.Buffer
+	if len(commands) == 0 {
+		return fmt.Errorf("runPipedCommands called with no commands")
+	}
+
+	// Build every *exec.Cmd up front.
 	cmds := make([]*exec.Cmd, len(commands))
-
-	// Create the first command
-	cmds[0] = exec.Command(commands[0][0], commands[0][1:]...)
-
-	for i := 1; i < len(commands); i++ {
-		// Create the next commands and pipe stdin to the previous stdout
+	for i := range commands {
 		cmds[i] = exec.Command(commands[i][0], commands[i][1:]...)
-		cmds[i].Stdin, _ = cmds[i-1].StdoutPipe()
-		err = cmds[i].Start()
-		if err != nil {
-			fmt.Printf("Error while starting command %d: %s\n", i+1, err)
-			return
+	}
+
+	// Wire each command's stdout into the next command's stdin. StdoutPipe must
+	// be obtained before the producing command is started, and its error must not
+	// be ignored: a dropped pipe error here would otherwise surface later as a
+	// confusing "broken pipe" or a silently empty downstream input.
+	for i := 1; i < len(cmds); i++ {
+		stdout, errPipe := cmds[i-1].StdoutPipe()
+		if errPipe != nil {
+			return fmt.Errorf("unable to connect command %d output to command %d input: %w", i, i+1, errPipe)
+		}
+		cmds[i].Stdin = stdout
+	}
+
+	// Capture the last command's output and stderr for diagnostics. These must be
+	// set before the command is started (exec.Cmd reads them at Start), which the
+	// previous implementation got wrong by assigning Stdout after Start.
+	var out bytes.Buffer
+	last := cmds[len(cmds)-1]
+	last.Stdout = &out
+	last.Stderr = &out
+
+	// Start every downstream command so they are ready to consume their piped
+	// input before the first command begins producing it.
+	for i := 1; i < len(cmds); i++ {
+		if err = cmds[i].Start(); err != nil {
+			return fmt.Errorf("unable to start command %d (%s): %w", i+1, commands[i][0], err)
 		}
 	}
 
-	// Create the last command and pipe stdout to a bytes buffer
-	cmds[len(commands)-1].Stdout = &out
-
-	// Run the first command
-	err = cmds[0].Run()
-	if err != nil {
-		fmt.Printf("Error while running first command: %s\n", err)
-		return
+	// Run the first command to completion; this drives the whole pipeline.
+	if err = cmds[0].Run(); err != nil {
+		return fmt.Errorf("unable to run command 1 (%s): %w", commands[0][0], err)
 	}
 
-	// Wait for the last command
-	err = cmds[len(commands)-1].Wait()
-	if err != nil {
-		// If erverything didn't go as planned, displaying the command output
-		fmt.Printf("Error while waiting for last command: %s\nOutput: %s\n", err, out.String())
-		return
+	// Wait for each downstream command, in order, to finish.
+	for i := 1; i < len(cmds); i++ {
+		if err = cmds[i].Wait(); err != nil {
+			return fmt.Errorf("command %d (%s) failed: %w\nOutput: %s", i+1, commands[i][0], err, out.String())
+		}
 	}
 
 	return

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -389,16 +389,31 @@ func (bu *User) GetSSHKeyPairs() (kp []*helpers.SSHKeyPair, err error) {
 	return
 }
 
-// GetTOTP returnds info about user's TOTP
-func (bu *User) GetTOTP() (enabled bool, secret string, emergencyPasswords []string) {
+// GetTOTP reports whether the calling user has TOTP (2FA) configured and, when
+// they do, returns the shared secret and the remaining emergency/scratch codes
+// read from their ~/.google_authenticator file.
+//
+// The enabled flag is true only when a well-formed file containing a secret line
+// is found. A missing file is the normal "TOTP not set up" case and is reported
+// as (false, "", nil, nil). Any other failure — the file cannot be read, or it
+// exists but is empty/truncated and carries no secret line — is returned as a
+// non-nil error so the caller can fail closed instead of acting on a missing
+// secret. Previously an empty or truncated file caused an index-out-of-range
+// panic at lines[0], which on the main.go startup path (run for every command
+// when replication is enabled) was a denial of service for the affected user.
+func (bu *User) GetTOTP() (enabled bool, secret string, emergencyPasswords []string, err error) {
 
 	file, err := os.Open(bu.GetTOTPFilepath())
 	if err != nil {
+		// A missing file simply means TOTP was never enabled; that is the normal
+		// case and not an error. Any other open error (e.g. permissions) is
+		// surfaced so the caller can decide how to handle it.
+		if os.IsNotExist(err) {
+			err = nil
+		}
 		return
 	}
 	defer file.Close()
-
-	enabled = true
 
 	lines := make([]string, 0)
 	scanner := bufio.NewScanner(file)
@@ -408,7 +423,21 @@ func (bu *User) GetTOTP() (enabled bool, secret string, emergencyPasswords []str
 			lines = append(lines, line)
 		}
 	}
+	if err = scanner.Err(); err != nil {
+		err = fmt.Errorf("unable to read TOTP file %s: %w", bu.GetTOTPFilepath(), err)
+		return
+	}
 
+	// The first non-option line is the shared secret; every line after it is an
+	// emergency/scratch code. A file with no secret line — or one whose first line
+	// is blank — is malformed: surface the corruption rather than panicking on
+	// lines[0] or returning an empty secret.
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
+		err = fmt.Errorf("TOTP file %s is empty or malformed: no secret found", bu.GetTOTPFilepath())
+		return
+	}
+
+	enabled = true
 	secret = lines[0]
 	emergencyPasswords = lines[1:]
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -242,9 +242,19 @@ func (bu *User) DeletePubKey(keyType string, pk helpers.PublicKey) (err error) {
 		// Manually closing the file before writing to it
 		file.Close()
 
-		// Writing the new content to the file (WriteFile actually truncates, then writes)
-		os.WriteFile(path, []byte(fmt.Sprintf("%s\n", strings.Join(keysToRetain, "\n"))), 0644)
+		// If reading the file failed partway through, do not overwrite it with a
+		// truncated key set — that could silently drop keys we meant to keep.
+		if err = scanner.Err(); err != nil {
+			return fmt.Errorf("unable to read %s while deleting key: %w", path, err)
+		}
 
+		// Write back the keys we are keeping (WriteFile truncates, then writes). A
+		// failed write must be reported: silently ignoring it could leave the
+		// key we are revoking still present in authorized_keys, so it would stay
+		// accepted and the revocation would not take effect.
+		if err = os.WriteFile(path, []byte(fmt.Sprintf("%s\n", strings.Join(keysToRetain, "\n"))), 0644); err != nil {
+			return fmt.Errorf("unable to write %s while deleting key: %w", path, err)
+		}
 	}
 
 	return

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -504,3 +504,51 @@ func TestGetTOTPMalformedFile(t *testing.T) {
 		})
 	}
 }
+
+// parseTestPublicKey builds a helpers.PublicKey from an authorized_keys line for
+// use in the DeletePubKey tests.
+func parseTestPublicKey(t *testing.T, line string) helpers.PublicKey {
+	t.Helper()
+	publicKey, comment, options, rest, err := ssh.ParseAuthorizedKey([]byte(line))
+	require.NoError(t, err, "failed to parse the test public key")
+	return helpers.PublicKey{PublicKey: publicKey, Comment: comment, Options: options, Rest: rest}
+}
+
+// TestDeletePubKeyReportsWriteError asserts that DeletePubKey surfaces a failure
+// to rewrite authorized_keys instead of silently ignoring it. A swallowed write
+// error would be a revocation bug: the key being removed could remain in the
+// file and stay accepted, so revocation would appear to succeed while the key
+// still worked.
+func TestDeletePubKeyReportsWriteError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("a write-permission failure cannot be provoked when running as root")
+	}
+
+	const key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxu5J1fpfRBHe/2JKreeDGgJlMZji3n97fYm3KJt8Yv sb@localhost"
+	pk := parseTestPublicKey(t, key)
+
+	// A readable but unwritable authorized_keys file: the open and scan succeed,
+	// but the subsequent rewrite fails with a permission error.
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	require.NoError(t, os.WriteFile(path, []byte(key+"\n"), 0444))
+
+	user := &User{User: &osuser.User{HomeDir: t.TempDir()}}
+	user.OverrideAuthorizedKeysFilePath(path)
+
+	err := user.DeletePubKey("ingress", pk)
+	require.Error(t, err, "a failed rewrite of authorized_keys must be reported")
+}
+
+// TestDeletePubKeyReportsReadError asserts that DeletePubKey aborts when the
+// authorized_keys file cannot be read cleanly, instead of overwriting it with a
+// possibly truncated key set. Pointing the path at a directory makes the open
+// succeed but the scan fail.
+func TestDeletePubKeyReportsReadError(t *testing.T) {
+	pk := parseTestPublicKey(t, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxu5J1fpfRBHe/2JKreeDGgJlMZji3n97fYm3KJt8Yv sb@localhost")
+
+	user := &User{User: &osuser.User{HomeDir: t.TempDir()}}
+	user.OverrideAuthorizedKeysFilePath(t.TempDir()) // a directory, not a file
+
+	err := user.DeletePubKey("ingress", pk)
+	require.Error(t, err, "a read failure must abort instead of overwriting with a truncated set")
+}

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -450,19 +450,57 @@ func TestTOTP(t *testing.T) {
 	testSecret := "randomstring"
 	testEmergencyCodes := []string{"10", "11", "12", "13", "14"}
 
-	enabled, _, _ := user.GetTOTP()
+	enabled, _, _, err := user.GetTOTP()
+	require.NoError(t, err, "reading a missing TOTP file should not be an error")
 	require.Equal(t, false, enabled, "The TOTP for this user should be disabled")
 
 	user.SetTOTPSecret(testSecret, testEmergencyCodes)
 
-	enabled, secret, emergencyCodes := user.GetTOTP()
+	enabled, secret, emergencyCodes, err := user.GetTOTP()
+	require.NoError(t, err, "reading a well-formed TOTP file should not error")
 	require.Equal(t, true, enabled, "The TOTP for this user should be enabled")
 	require.Equal(t, testSecret, secret, "The secret value is unexpected")
 	require.Equal(t, testEmergencyCodes, emergencyCodes, "The emergency codes are unexpected")
 
-	err := user.RemoveTOTPSecret()
+	err = user.RemoveTOTPSecret()
 	require.NoError(t, err, "An unexpected error occurred when removing TOTP")
 
-	enabled, _, _ = user.GetTOTP()
+	enabled, _, _, err = user.GetTOTP()
+	require.NoError(t, err, "reading a removed TOTP file should not be an error")
 	require.Equal(t, false, enabled, "The TOTP for this user should be disabled")
+}
+
+// TestGetTOTPMalformedFile asserts that GetTOTP fails closed — returns an error
+// instead of panicking — when the .google_authenticator file exists but holds no
+// secret line. The google_authenticator format puts the shared secret on the
+// first line and option lines start with a double quote; a file made up of only
+// option lines (or an empty file) therefore has no secret. Before this change,
+// indexing the empty slice at lines[0] panicked, which on the per-command
+// startup path was a denial of service for the affected user.
+func TestGetTOTPMalformedFile(t *testing.T) {
+	tests := map[string]string{
+		"empty file":        "",
+		"only option lines": "\" RATE_LIMIT 3 30\n\" WINDOW_SIZE 17\n",
+		"trailing newlines": "\n\n",
+	}
+
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			// A throwaway home directory keeps the test hermetic — it never
+			// touches the shared test_assets fixtures.
+			home := t.TempDir()
+			user := &User{User: &osuser.User{HomeDir: home}}
+
+			err := os.WriteFile(filepath.Join(home, ".google_authenticator"), []byte(content), 0600)
+			require.NoError(t, err, "failed to write the malformed TOTP fixture")
+
+			require.NotPanics(t, func() {
+				enabled, secret, codes, totpErr := user.GetTOTP()
+				require.Error(t, totpErr, "a secret-less TOTP file must be reported as an error")
+				require.False(t, enabled, "a malformed TOTP file must not be reported as enabled")
+				require.Empty(t, secret, "no secret should be returned for a malformed file")
+				require.Empty(t, codes, "no emergency codes should be returned for a malformed file")
+			}, "GetTOTP must not panic on a malformed file")
+		})
+	}
 }

--- a/main.go
+++ b/main.go
@@ -29,10 +29,14 @@ func main() {
 	// If replication is enabled
 	if config.GetReplicationEnabled() {
 
-		totpEnabled, secret, totpEmergency := currentUser.GetTOTP()
+		totpEnabled, secret, totpEmergency, totpErr := currentUser.GetTOTP()
 
-		// And user has TOTP enabled
-		if totpEnabled {
+		// A corrupt or unreadable TOTP file must not abort every command this user
+		// runs: warn and skip the recovery-code replication sync rather than
+		// failing the whole invocation.
+		if totpErr != nil {
+			fmt.Printf("warning: unable to read TOTP state, skipping replication sync: %s\n", totpErr)
+		} else if totpEnabled {
 
 			// Maybe the user used a recovery code, and we need to sync it to the other instances
 			dbHandler, err := models.GetReplicationGormDB(config.GetReplicationDatabasePath())


### PR DESCRIPTION
## Summary

Three related robustness fixes where an error was previously swallowed or could panic, each with security impact. Delivered as a three-commit arc (each commit builds and passes the suite independently).

### 1. `GetTOTP` fails closed instead of panicking
`User.GetTOTP` took `lines[0]` as the TOTP secret without checking the slice was non-empty. A `~/.google_authenticator` file that exists but has no secret line (empty, truncated, option-only, or blank-first-line) caused an index-out-of-range **panic**. On the `main.go` startup path — which calls `GetTOTP` for every command when replication is enabled — that panic was a **denial of service**: the affected user could run nothing.

`GetTOTP` now returns an `error`. A missing file stays the normal "not set up" case; any read failure or secret-less file is reported so callers fail closed. Call sites updated accordingly: the startup sync warns and skips (never crashes the invocation); `selfEnableTOTP`/`selfGenerateTOTPCodes` abort rather than act on a corrupt file; `info` shows the status as unavailable inline.

### 2. `DeletePubKey` reports rewrite failures
`DeletePubKey` rewrote `authorized_keys` with `os.WriteFile` and **discarded the error** (and never checked the scanner error). A failed rewrite returned `nil` as though the key were removed while the file still contained it — a silent **key-revocation bug**: the revoked key would keep being accepted. A mid-scan read error could also overwrite the file with a truncated key set.

It now checks `scanner.Err()` before rewriting and returns the wrapped `os.WriteFile` error, so a caller learns when a key could not actually be removed.

### 3. `runPipedCommands` handles pipe and start errors
The helper dropped the `StdoutPipe` error, set the last command's output buffer **after** starting it (so the diagnostic buffer was always empty), and only waited on the final command. Failures in the `echo | tee` helpers that write keys and the sudoers file could be silently lost.

Rewritten to reject an empty list, capture each `StdoutPipe` error before the producing command starts, set the output buffer before `Start`, start all downstream commands, run the first, and wait on each in order — wrapping every failure with the command index, name and captured output. Success behavior for the existing two-stage callers is unchanged.

## How it's tested

- Hermetic table-driven test for `GetTOTP` (empty / option-only / blank-line files) asserting it errors and does not panic, plus the updated TOTP round-trip test.
- Two hermetic tests for `DeletePubKey`: a read-only `authorized_keys` (rewrite fails; skipped as root) and a directory path (read fails).
- Hermetic table-driven test for `runPipedCommands` using `echo`/`cat`/`true`/`false` covering single/multi-stage success, empty list, un-startable command, first-command failure, and a downstream non-zero exit.
- `go build ./...`, `go test ./...` and `golangci-lint run` are clean at every commit.

### Reviewer checklist
- [ ] `GetTOTP` error handling at each call site matches the intended fail-closed vs. fail-soft choice
- [ ] `DeletePubKey` now surfacing errors won't break existing happy-path callers
- [ ] `runPipedCommands` rewrite preserves the `echo | tee` success behavior