### PR TITLE
setup: harden root login and validate sshd config before restart

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -62,6 +62,20 @@ func (c *Setup) Execute(ct *commands.Context) (repl models.ReplicationData, cmdE
 		return
 	}
 
+	// Validate the new configuration before we ever restart sshd. A syntax error
+	// or rejected option would otherwise only surface when the service restarts,
+	// potentially leaving sshd down and locking everyone out of the host. If the
+	// test fails, restore the backup so the on-disk config stays bootable.
+	log.Printf("[SETUP     ] Validating new SSHD configuration with sshd -t...")
+	err = validateSSHDConfig(DefaultSSHDConfigFile)
+	if err != nil {
+		log.Printf("[SETUP     ] New SSHD configuration is invalid, restoring backup: %s", err)
+		if restoreErr := c._restoreFile(backupSSHD, DefaultSSHDConfigFile); restoreErr != nil {
+			log.Printf("[SETUP     ] Failed to restore SSHD config backup: %s", restoreErr)
+		}
+		return
+	}
+
 	// Remove password auth in PAM
 	_, err = exec.LookPath("google-authenticator")
 	if err == nil {
@@ -149,6 +163,32 @@ func (c *Setup) _backupFile(path string) (backup string, err error) {
 	return
 }
 
+func (c *Setup) _restoreFile(backup, path string) (err error) {
+	return exec.Command("cp", backup, path).Run()
+}
+
+// validateSSHDConfig runs `sshd -t` against the given config file and returns an
+// error (including sshd's own output) if the configuration is invalid. It is a
+// package variable wrapping the real command so the surrounding control flow can
+// be tested without a real sshd.
+var validateSSHDConfig = func(path string) error {
+	return validateSSHDConfigWith(path, func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).CombinedOutput()
+	})
+}
+
+// validateSSHDConfigWith runs the sshd config test through the provided command
+// runner, returning a descriptive error (with the captured output) when sshd
+// reports the configuration as invalid. The runner is injected so tests can
+// exercise both the success and failure paths hermetically.
+func validateSSHDConfigWith(path string, run func(name string, args ...string) ([]byte, error)) error {
+	out, err := run("sshd", "-t", "-f", path)
+	if err != nil {
+		return fmt.Errorf("sshd configuration test failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 func (c *Setup) _SetSSHDOptions() (err error) {
 
 	p, err := helpers.ParseSSHDConfigFile(DefaultSSHDConfigFile)
@@ -162,11 +202,14 @@ func (c *Setup) _SetSSHDOptions() (err error) {
 	log.Printf("[SETUP     ]   -> Switch %-32s to yes", "KbdInteractiveAuthentication")
 	p.SetParam("KbdInteractiveAuthentication", "yes")
 
-	log.Printf("[SETUP     ]   -> Switch %-32s to yes", "PasswordAuthentication")
+	log.Printf("[SETUP     ]   -> Switch %-32s to no", "PasswordAuthentication")
 	p.SetParam("PasswordAuthentication", "no")
 
-	log.Printf("[SETUP     ]   -> Switch %-32s to yes", "PermitRootLogin")
-	p.SetParam("PermitRootLogin", "yes")
+	// prohibit-password lets key/cert-based root automation keep working while
+	// refusing interactive root password logins; full "yes" would have allowed
+	// password root logins on the bastion's own sshd.
+	log.Printf("[SETUP     ]   -> Switch %-32s to prohibit-password", "PermitRootLogin")
+	p.SetParam("PermitRootLogin", "prohibit-password")
 
 	log.Printf("[SETUP     ]   -> Switch %-32s to publickey,keyboard-interactive", "AuthenticationMethods")
 	p.SetParam("AuthenticationMethods", "publickey,keyboard-interactive")

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golgeek/sb/internal/helpers"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetSSHDOptions verifies the hardened sshd options the setup writes,
+// notably that root login is set to prohibit-password (not the previous "yes")
+// and password authentication is disabled. It runs against a temporary config
+// file so it never touches the host's real /etc/ssh/sshd_config.
+func TestSetSSHDOptions(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "sshd_config")
+
+	initial := "# test sshd config\n" +
+		"PermitRootLogin yes\n" +
+		"PasswordAuthentication yes\n" +
+		"ChallengeResponseAuthentication no\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(initial), 0644))
+
+	// Point the setup at the temporary file and restore the default afterwards.
+	original := DefaultSSHDConfigFile
+	DefaultSSHDConfigFile = cfgPath
+	t.Cleanup(func() { DefaultSSHDConfigFile = original })
+
+	c := new(Setup)
+	require.NoError(t, c._SetSSHDOptions())
+
+	p, err := helpers.ParseSSHDConfigFile(cfgPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "prohibit-password", p.GetParam("PermitRootLogin"), "root login must be prohibit-password, not yes")
+	require.Equal(t, "no", p.GetParam("PasswordAuthentication"))
+	require.Equal(t, "yes", p.GetParam("ChallengeResponseAuthentication"))
+	require.Equal(t, "yes", p.GetParam("KbdInteractiveAuthentication"))
+	require.Equal(t, "publickey,keyboard-interactive", p.GetParam("AuthenticationMethods"))
+}
+
+// TestValidateSSHDConfigWithSuccess asserts the config validator invokes
+// `sshd -t -f <path>` and returns no error when sshd accepts the file.
+func TestValidateSSHDConfigWithSuccess(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+
+	err := validateSSHDConfigWith("/etc/ssh/sshd_config", func(name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = args
+		return nil, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "sshd", gotName)
+	require.Equal(t, []string{"-t", "-f", "/etc/ssh/sshd_config"}, gotArgs)
+}
+
+// TestValidateSSHDConfigWithFailure asserts that when sshd rejects the config,
+// the validator returns an error carrying sshd's output — the signal the setup
+// uses to abort the restart and restore the backup rather than lock the host.
+func TestValidateSSHDConfigWithFailure(t *testing.T) {
+	err := validateSSHDConfigWith("/tmp/broken", func(name string, args ...string) ([]byte, error) {
+		return []byte("/tmp/broken: line 5: Bad configuration option"), errors.New("exit status 255")
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sshd configuration test failed")
+	require.Contains(t, err.Error(), "Bad configuration option", "sshd's output should be surfaced to the operator")
+}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,8 +110,13 @@ Notably,
 - in `/etc/ssh/sshd_config`:
   - [x] make sure that `PasswordAuthentication` is set to `no`
   - [x] make sure that `ChallengeResponseAuthentication` is set to `yes` (to enable TOTP)
-  - [x] make sure that `PermitRootLogin` is set to `yes` to allow maintenance operations
+  - [x] make sure that `PermitRootLogin` is set to `prohibit-password` (key/cert-based root maintenance still works; interactive root password logins are refused)
   - [x] make sure that `AuthenticationMethods` is set to `publickey,keyboard-interactive`
+
+The setup also validates the resulting configuration with `sshd -t` before
+restarting the SSH service. If the configuration is invalid, the original file is
+restored and the service is not restarted, so a mistake cannot lock you out of
+the host.
 - configure `/etc/pam.d/sshd` to enable TOTP via `pam_google_authenticator` if it is installed on the system
 - create the technical `sb` user
 - create the `sudoers.d` file for sb `owners` group so that owners can create groups and users


### PR DESCRIPTION
## Summary

Hardens the bastion's own SSH configuration during `sb setup` and removes a lockout risk by validating the config with `sshd -t` before restarting the service.

## Previous behavior

`sb setup` wrote `PermitRootLogin yes` into `/etc/ssh/sshd_config` and then ran `service ssh restart` **without** first testing the new configuration.

## Why it was a problem

- `PermitRootLogin yes` permits interactive **root password logins** on the bastion's sshd — weaker than necessary.
- Restarting sshd without testing the config risks a **lockout**: a syntax error or rejected option only surfaces at restart, when sshd may fail to come back up and nobody can SSH in to fix it.

## What changed

- Sets **`PermitRootLogin prohibit-password`** — key/cert-based root maintenance still works, interactive root password logins are refused.
- **Validates the new config with `sshd -t` before any restart.** On failure, the backup taken at the start of setup is restored and setup returns **without restarting**, so the on-disk config stays bootable.
- The validator is factored behind an injected command runner so its success/failure handling is unit-testable without a real sshd.
- Fixed two log lines that printed "to yes" while setting other values; updated `docs/installation.md`.

## How it's tested

- Hermetic test running the option-setting against a temp config file, asserting `PermitRootLogin=prohibit-password` and `PasswordAuthentication=no` (plus the other expected options).
- Tests that the validator invokes `sshd -t -f <path>` and surfaces sshd's output as an error on failure.
- `go build ./...`, `go test ./...`, `golangci-lint run` all clean.

### Reviewer checklist
- [ ] `prohibit-password` is the right policy for your root-maintenance workflow
- [ ] Restoring the backup (rather than leaving the new file) on validation failure is the desired behavior
- [ ] `sshd` resolvable on the host's PATH at setup time