### PR TITLE
ci: enable errcheck and gosec linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ linters:
   default: none
   enable:
     - bodyclose
+    - errcheck
     - gocritic
     - govet
     - ineffassign

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
     - bodyclose
     - errcheck
     - gocritic
+    - gosec
     - govet
     - ineffassign
     - misspell
@@ -25,6 +26,21 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      # sb is an SSH bastion: it shells out to sudo/ssh/adduser/usermod for every
+      # privileged action, so exec.Command with computed arguments is inherent and
+      # reviewed. exec.Command never invokes a shell (no shell injection) and
+      # user-supplied user/group names are validated at the helper boundary
+      # (helpers.ValidateSystemName), so gosec's G204 is noise for this codebase.
+      - linters:
+          - gosec
+        text: "G204"
+      # Test code uses controlled, local inputs (t.TempDir, fixed fixtures); gosec's
+      # taint/permission heuristics (e.g. G703 path traversal, G306 file mode)
+      # raise false positives there.
+      - linters:
+          - gosec
+        path: _test\.go
     paths:
       - third_party$
       - builtin$

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -66,11 +66,19 @@ func (c *Daemon) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 	// If replication is enabled, we start replicating other instances' actions
 	if replicationQueueConfig.Enabled {
 		c.replicated = dedupcache.New(5 * time.Minute)
-		go c.consumeReplicationEvents(rq)
+		go func() {
+			if err := c.consumeReplicationEvents(rq); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: replication consumer stopped: %s\n", err)
+			}
+		}()
 	}
 
 	// Handle post executions and potentially push events to other instances via the queue
-	go c.publishReplicationEvents(rq, !replicationQueueConfig.Enabled)
+	go func() {
+		if err := c.publishReplicationEvents(rq, !replicationQueueConfig.Enabled); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: replication publisher stopped: %s\n", err)
+		}
+	}()
 
 	// Let's just wait indefinitely
 	select {}

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -165,7 +165,10 @@ func (c *Interactive) promptExecutor(command string) {
 		fmt.Printf("Error while executing command: %s\n", err)
 	}
 	log.SessionEndDate = time.Now()
-	log.Save()
+	// Best-effort final audit write; report a failure rather than dropping it.
+	if err := log.Save(); err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: unable to persist audit log: %s\n", err)
+	}
 }
 
 func (c *Interactive) promptCompleter(d prompt.Document) ([]prompt.Suggest, istrings.RuneNumber, istrings.RuneNumber) {

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -110,7 +110,10 @@ func (c *Scp) Execute(ct *commands.Context) (repl models.ReplicationData, cmdErr
 		fmt.Printf("Error: %s", err)
 		return
 	}
-	ct.Log.SetTargetAccess(access)
+	// Best-effort audit write; log a failure rather than aborting the transfer.
+	if err := ct.Log.SetTargetAccess(access); err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: unable to persist target access in audit log: %s\n", err)
+	}
 
 	// Get ssh command path on the system
 	sshPath, err := exec.LookPath("ssh")

--- a/cmd/ttyrec.go
+++ b/cmd/ttyrec.go
@@ -62,8 +62,12 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 		return
 	}
 
-	// We override the currently stored access (which might be an alias) with the final one
-	ct.Log.SetTargetAccess(access)
+	// We override the currently stored access (which might be an alias) with the
+	// final one. This is a best-effort audit write, so a failure is logged rather
+	// than aborting the connection the user is establishing.
+	if err := ct.Log.SetTargetAccess(access); err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: unable to persist target access in audit log: %s\n", err)
+	}
 
 	// We will provide the ttyrec record path as a replication data for the post exec step
 	repl = models.ReplicationData{
@@ -108,25 +112,23 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 	}
 	defer stderr.Close()
 
-	// Handle ttyrec to a file
-	go func(filename string, r io.Reader) (written int64, err error) {
+	// Handle ttyrec to a file. This runs in its own goroutine, so it cannot return
+	// an error to the caller; it logs any failure to stderr instead of dropping it
+	// silently, which previously hid a failed session recording.
+	go func(filename string, r io.Reader) {
 
 		f, err := os.Create(filename)
 		if err != nil {
-			err = fmt.Errorf("unable to open ttyrec file: %w", err)
+			fmt.Fprintf(os.Stderr, "ERROR: unable to open ttyrec file: %s\n", err)
 			return
 		}
 		defer f.Close()
 
 		e := ttyrec.NewEncoder(f)
 
-		written, err = io.Copy(e, r)
-		if err != nil {
-			err = fmt.Errorf("unable to write SSH session to ttyrec: %w", err)
-			return
+		if _, err := io.Copy(e, r); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: unable to write SSH session to ttyrec: %s\n", err)
 		}
-
-		return
 	}(
 		repl["ttyrec-record-path"],
 		io.MultiReader(

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,6 +18,16 @@ import (
 var (
 	commands map[string]Factory
 )
+
+// logAuditWarn reports a best-effort audit-log persistence failure to stderr
+// without failing the command. The authorization decision has already been made
+// by the time these writes happen, so a logging hiccup must not change the
+// command's outcome — but it must not be silently swallowed either.
+func logAuditWarn(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: unable to persist audit log: %s\n", err)
+	}
+}
 
 func RegisterCommand(name string, command Factory) {
 	if commands == nil {
@@ -115,8 +126,10 @@ func buildArgumentsList(trustedArguments map[string]Argument, args []string) (ar
 		}
 	}
 
-	// Parse the user arguments
-	flagset.Parse(args)
+	// Parse the user arguments. As noted above, undeclared flags are tolerated by
+	// design (their output is sent to an abandoned buffer), so the parse error is
+	// intentionally ignored and the remaining args are recovered via Args below.
+	_ = flagset.Parse(args)
 
 	// Get the remaining arguments for future use
 	rest = flagset.Args()
@@ -204,7 +217,7 @@ func BuildSBCommand(log *models.Log, user *models.User, args ...string) (bc Comm
 	}
 
 	// Log the command we used
-	log.SetCommand(args[0])
+	logAuditWarn(log.SetCommand(args[0]))
 
 	// Let's start by displaying the helper if user asked for it
 	if len(args) > 1 && (args[1] == "help" || args[1] == "?") {
@@ -249,14 +262,14 @@ func BuildSBCommand(log *models.Log, user *models.User, args ...string) (bc Comm
 				return bc, ct, err
 			}
 
-			log.SetTargetAccess(ba)
+			logAuditWarn(log.SetTargetAccess(ba))
 
 			ai, err := user.HasAccess(ba)
 			if err != nil {
 				return bc, ct, err
 			}
 			if !ai.Authorized {
-				log.SetAllowed(false)
+				logAuditWarn(log.SetAllowed(false))
 				return bc, ct, fmt.Errorf("user can't access the host %s", ba.ShortString())
 			}
 
@@ -265,27 +278,27 @@ func BuildSBCommand(log *models.Log, user *models.User, args ...string) (bc Comm
 		}
 	case models.GroupMember:
 		if !user.IsMemberOfGroup(grp.Name) {
-			log.SetAllowed(false)
+			logAuditWarn(log.SetAllowed(false))
 			return bc, ct, fmt.Errorf("user is not a member of the group")
 		}
 	case models.GroupACLKeeper:
 		if !user.IsACLKeeperOfGroup(grp.Name) {
-			log.SetAllowed(false)
+			logAuditWarn(log.SetAllowed(false))
 			return bc, ct, fmt.Errorf("user is not an ACL keeper of the group")
 		}
 	case models.GroupGateKeeper:
 		if !user.IsGateKeeperOfGroup(grp.Name) {
-			log.SetAllowed(false)
+			logAuditWarn(log.SetAllowed(false))
 			return bc, ct, fmt.Errorf("user is not a gate keeper of the group")
 		}
 	case models.GroupOwner:
 		if !user.IsOwnerOfGroup(grp.Name) && !user.IsOwnerOfGroup("owners") {
-			log.SetAllowed(false)
+			logAuditWarn(log.SetAllowed(false))
 			return bc, ct, fmt.Errorf("user is not an owner of the group")
 		}
 	case models.SBOwner:
 		if !user.IsOwnerOfGroup("owners") && user.User.Uid != "0" {
-			log.SetAllowed(false)
+			logAuditWarn(log.SetAllowed(false))
 			return bc, ct, fmt.Errorf("user is not a sb owner")
 		}
 	}
@@ -293,11 +306,11 @@ func BuildSBCommand(log *models.Log, user *models.User, args ...string) (bc Comm
 	// Call the check method
 	err = bc.Checks(ct)
 	if err != nil {
-		log.SetAllowed(false)
+		logAuditWarn(log.SetAllowed(false))
 		return
 	}
 
-	log.SetAllowed(true)
+	logAuditWarn(log.SetAllowed(true))
 
 	return
 }

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -90,8 +90,10 @@ func ParseArgumentsNew(clArgs []string) (c string, ca []string, rest []string, e
 		lang := moshFlagSet.String("l", "", "Locale-related environment variable to try as part of a fallback environment, if the startup environment does not specify a character set of UTF-8.")
 		moshFlagSet.String("p", "", "UDP port number or port-range to bind.  -p 0 will let the operating system pick an available UDP port.")
 
-		// Let's parse our mosh-server arguments
-		moshFlagSet.Parse(clArgs)
+		// Let's parse our mosh-server arguments. We intentionally ignore the parse
+		// error and proceed best-effort: undeclared mosh flags are expected here and
+		// must not abort parsing (the remaining args are recovered via Args below).
+		_ = moshFlagSet.Parse(clArgs)
 
 		// And keep everything that was trailing for the next step
 		clArgs = moshFlagSet.Args()
@@ -193,8 +195,10 @@ func ParseArguments(clArgs []string) (c string, ca []string, ba map[string]bool,
 		lang := moshFlagSet.String("l", "", "Locale-related environment variable to try as part of a fallback environment, if the startup environment does not specify a character set of UTF-8.")
 		moshFlagSet.String("p", "", "UDP port number or port-range to bind.  -p 0 will let the operating system pick an available UDP port.")
 
-		// Let's parse our mosh-server arguments
-		moshFlagSet.Parse(clArgs)
+		// Let's parse our mosh-server arguments. We intentionally ignore the parse
+		// error and proceed best-effort: undeclared mosh flags are expected here and
+		// must not abort parsing (the remaining args are recovered via Args below).
+		_ = moshFlagSet.Parse(clArgs)
 
 		// And keep everything that was trailing for the next step
 		clArgs = moshFlagSet.Args()
@@ -234,8 +238,10 @@ func ParseArguments(clArgs []string) (c string, ca []string, ba map[string]bool,
 	i := sbFlagSet.Bool("i", false, "Interactive mode")
 	d := sbFlagSet.Bool("d", false, "Daemon")
 
-	// Let's parse our sb arguments
-	sbFlagSet.Parse(clArgs)
+	// Let's parse our sb arguments. The parse error is intentionally ignored:
+	// undeclared flags are expected (they belong to the wrapped client) and the
+	// trailing args are recovered via Args below.
+	_ = sbFlagSet.Parse(clArgs)
 
 	// And keep everything that was trailing for the next step
 	clArgs = sbFlagSet.Args()

--- a/internal/helpers/ssh.go
+++ b/internal/helpers/ssh.go
@@ -319,8 +319,10 @@ func bcryptHash(out, shapass, shasalt []byte) {
 			c.Encrypt(out[i:i+8], out[i:i+8])
 		}
 	}
-	// Swap bytes due to different endianness.
+	// Swap bytes due to different endianness. This is a verbatim copy of
+	// x/crypto's bcrypt_pbkdf; out is always the fixed 32-byte buffer the caller
+	// allocates, so i+3 (max 31) is always in range.
 	for i := 0; i < 32; i += 4 {
-		out[i+3], out[i+2], out[i+1], out[i] = out[i], out[i+1], out[i+2], out[i+3]
+		out[i+3], out[i+2], out[i+1], out[i] = out[i], out[i+1], out[i+2], out[i+3] //nolint:gosec // G602: out is a fixed 32-byte buffer
 	}
 }

--- a/internal/helpers/system.go
+++ b/internal/helpers/system.go
@@ -389,7 +389,9 @@ func WriteSelfPrivateKey(privateKey, privateKeyFile, owner string) (err error) {
 }
 
 func WriteSelfPublicKey(publicKey, publicKeyFile, owner string) (err error) {
-	err = os.WriteFile(publicKeyFile, []byte(publicKey), 0644)
+	// A public key is not secret and follows the conventional world-readable 0644
+	// mode for .pub files, so the broader-than-0600 permission is intentional.
+	err = os.WriteFile(publicKeyFile, []byte(publicKey), 0644) //nolint:gosec // G306: public key file, intentionally world-readable
 	if err != nil {
 		return
 	}

--- a/internal/helpers/templates.go
+++ b/internal/helpers/templates.go
@@ -33,7 +33,11 @@ func getGroupSudoersTemplate(groupname string) (str string) {
 		panic(err)
 	}
 	out := new(bytes.Buffer)
-	t.Execute(out, groupname)
+	// The template and its data are static and trusted; a failure here is a
+	// programming error, matching the panic on Parse above.
+	if err := t.Execute(out, groupname); err != nil {
+		panic(err)
+	}
 
 	return out.String()
 
@@ -77,7 +81,11 @@ WantedBy=multi-user.target`
 		panic(err)
 	}
 	out := new(bytes.Buffer)
-	t.Execute(out, tplData)
+	// The template and its data are static and trusted; a failure here is a
+	// programming error, matching the panic on Parse above.
+	if err := t.Execute(out, tplData); err != nil {
+		panic(err)
+	}
 
 	return out.String()
 }
@@ -160,7 +168,11 @@ func GetGroupSudoersTemplateOwners(binaryPath, sbUser string) (str string) {
 		panic(err)
 	}
 	out := new(bytes.Buffer)
-	t.Execute(out, tplData)
+	// The template and its data are static and trusted; a failure here is a
+	// programming error, matching the panic on Parse above.
+	if err := t.Execute(out, tplData); err != nil {
+		panic(err)
+	}
 
 	return out.String()
 }
@@ -208,7 +220,11 @@ exec ssh -p {{.Port}} {{.User}}@{{.Host}} $sshcmdline -T -- scp --access $host -
 		panic(err)
 	}
 	out := new(bytes.Buffer)
-	t.Execute(out, tplData)
+	// The template and its data are static and trusted; a failure here is a
+	// programming error, matching the panic on Parse above.
+	if err := t.Execute(out, tplData); err != nil {
+		panic(err)
+	}
 
 	return out.String()
 
@@ -239,7 +255,11 @@ func GetTOTPFile(secret string, emergencyCodes []string) (str string) {
 		panic(err)
 	}
 	out := new(bytes.Buffer)
-	t.Execute(out, tplData)
+	// The template and its data are static and trusted; a failure here is a
+	// programming error, matching the panic on Parse above.
+	if err := t.Execute(out, tplData); err != nil {
+		panic(err)
+	}
 
 	return out.String()
 

--- a/internal/models/log.go
+++ b/internal/models/log.go
@@ -70,7 +70,11 @@ func NewLog(username string, databases []string, arguments []string) (log *Log) 
 
 	log.Databases = databases
 
-	log.insert(true)
+	// Best-effort audit write: NewLog has no error return, so surface a failure to
+	// stderr rather than dropping the new log entry silently.
+	if err := log.insert(true); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: unable to persist new log entry: %s\n", err)
+	}
 
 	if config.GetReplicationEnabled() {
 		err := log.PushReplication(true)
@@ -101,7 +105,9 @@ func GetLastSSHSessions(database string, limit int) (sessions []*helpers.SSHSess
 	defer sqlDB.Close()
 
 	// Migrate the schema (this will create table or alter table if needed)
-	db.AutoMigrate(&Log{})
+	if err = db.AutoMigrate(&Log{}); err != nil {
+		return
+	}
 
 	// Select
 	err = db.Where("command = ?", "ttyrec").Order("session_start_date desc").Limit(limit).Find(&logs).Error
@@ -228,7 +234,9 @@ func (l *Log) insert(insert bool) (err error) {
 		defer sqlDB.Close()
 
 		// Migrate the schema (this will create table or alter table if needed)
-		db.AutoMigrate(&Log{})
+		if err = db.AutoMigrate(&Log{}); err != nil {
+			return fmt.Errorf("unable to migrate logs schema in %s: %w", dbPath, err)
+		}
 
 		// We insert our log
 		if insert {

--- a/internal/models/log_test.go
+++ b/internal/models/log_test.go
@@ -24,14 +24,14 @@ func TestNewLog(t *testing.T) {
 	log := NewLog("test", []string{logsDatabase}, []string{"test"})
 	require.IsType(t, &Log{}, log, "NewLog should return a Log{} object")
 
-	log.SetAllowed(true)
+	require.NoError(t, log.SetAllowed(true))
 	require.Equal(t, true, log.Allowed, "Allowed should be set to true after the SetAllowed() call")
 
-	log.SetCommand("selfAddAccess")
+	require.NoError(t, log.SetCommand("selfAddAccess"))
 	require.Equal(t, "selfAddAccess", log.Command, "Command should be set to selfAddAccess after the SetCommand() call")
 
 	ba, _ := BuildSBAccess("test.com", "root", "22022", "", false)
-	log.SetTargetAccess(ba)
+	require.NoError(t, log.SetTargetAccess(ba))
 	require.Equal(t, "test.com", log.HostTo, "HostTo should be set to test.com after the SetTargetAccess() call")
 	require.Equal(t, "22022", log.PortTo, "PortTo should be set to 22022 after the SetTargetAccess() call")
 	require.Equal(t, "root", log.UserTo, "UserTo should be set to root after the SetTargetAccess() call")

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -21,7 +21,10 @@ func GetAccessGormDB(database string) (db *gorm.DB, err error) {
 	}
 
 	// Migrate the schema (this will create table or alter table if needed)
-	db.AutoMigrate(&Access{})
+	if err = db.AutoMigrate(&Access{}); err != nil {
+		err = fmt.Errorf("failed to migrate access schema for %s: %w", database, err)
+		return
+	}
 
 	return
 }
@@ -39,7 +42,10 @@ func GetReplicationGormDB(database string) (db *gorm.DB, err error) {
 	}
 
 	// Migrate the schema (this will create table or alter table if needed)
-	db.AutoMigrate(&Replication{})
+	if err = db.AutoMigrate(&Replication{}); err != nil {
+		err = fmt.Errorf("failed to migrate replication schema for %s: %w", database, err)
+		return
+	}
 
 	return
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -252,7 +252,9 @@ func (bu *User) DeletePubKey(keyType string, pk helpers.PublicKey) (err error) {
 		// failed write must be reported: silently ignoring it could leave the
 		// key we are revoking still present in authorized_keys, so it would stay
 		// accepted and the revocation would not take effect.
-		if err = os.WriteFile(path, []byte(fmt.Sprintf("%s\n", strings.Join(keysToRetain, "\n"))), 0644); err != nil {
+		// authorized_keys holds public keys (not secret) and is read group-wide by
+		// the sb tooling, so the broader-than-0600 permission is intentional.
+		if err = os.WriteFile(path, []byte(fmt.Sprintf("%s\n", strings.Join(keysToRetain, "\n"))), 0644); err != nil { //nolint:gosec // G306: authorized_keys, public keys read group-wide
 			return fmt.Errorf("unable to write %s while deleting key: %w", path, err)
 		}
 	}

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -168,7 +168,7 @@ func TestManageKeys(t *testing.T) {
 
 	// Start by overriding the authorized_keys file path
 	file, _ := os.CreateTemp("/tmp", "")
-	user.OverrideAuthorizedKeysFilePath(file.Name())
+	require.NoError(t, user.OverrideAuthorizedKeysFilePath(file.Name()))
 
 	// Add a new ingress key
 	pubKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDviAgF0HG8m+Fu93Ob0ZgNsboHED1FEi7/LhakVO55Jka0HVV/dKm1Dg+X0+pHlKNteRrLjBT9MA8+cjTdpxCYj/jWovlUcBqZupJTi+xvSGP4q2flZdKTUh+D/bhTwcrQ910BwAzR9iMGqny3m4F62GUTQayhNMHpkOl6wicdwuMN6BYLrcm5qy9tpq0IrBYBWPyi/7knbMNTEH0UqjIIAfrO5ZHlfRs6jJ5R9gMBuJ/C4PIslzIG8WCyzS5kKrSz14xBldcj63eHtoB1ZU6RuaN4OluJLzdFFkRfGsVWQ6sVhpIMAJRCddRD2oACeHzlZiA7k32ddUKuw4Y3v1B sb@localhost"
@@ -274,7 +274,7 @@ func TestLastSSHSessions(t *testing.T) {
 		Groups: map[string]*Group{},
 	}
 
-	user.OverrideDatabaseAccessFilePath(":memory:")
+	require.NoError(t, user.OverrideDatabaseAccessFilePath(":memory:"))
 
 	sessions, err := user.GetLastSSHSessions(20)
 	require.NoError(t, err, "An unexpected error occurred when calling GetLastSSHSessions()")
@@ -299,7 +299,7 @@ func TestUserAccesses(t *testing.T) {
 	}
 
 	// Add with classic DB
-	user.OverrideDatabaseAccessFilePath(":memory:")
+	require.NoError(t, user.OverrideDatabaseAccessFilePath(":memory:"))
 
 	_, err := user.AddAccess("test.com", "root", "22", "test", "Added for tests")
 	require.NoError(t, err, "An unexpected error occurred when calling AddAccess")
@@ -454,7 +454,11 @@ func TestTOTP(t *testing.T) {
 	require.NoError(t, err, "reading a missing TOTP file should not be an error")
 	require.Equal(t, false, enabled, "The TOTP for this user should be disabled")
 
-	user.SetTOTPSecret(testSecret, testEmergencyCodes)
+	// SetTOTPSecret writes the secret file (which is what this test needs) and
+	// then chowns it to the target user, which requires root. Unprivileged in the
+	// test environment that chown fails, so the error is intentionally ignored
+	// here; the written content is still verified by GetTOTP below.
+	_ = user.SetTOTPSecret(testSecret, testEmergencyCodes)
 
 	enabled, secret, emergencyCodes, err := user.GetTOTP()
 	require.NoError(t, err, "reading a well-formed TOTP file should not error")
@@ -533,7 +537,7 @@ func TestDeletePubKeyReportsWriteError(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(key+"\n"), 0444))
 
 	user := &User{User: &osuser.User{HomeDir: t.TempDir()}}
-	user.OverrideAuthorizedKeysFilePath(path)
+	require.NoError(t, user.OverrideAuthorizedKeysFilePath(path))
 
 	err := user.DeletePubKey("ingress", pk)
 	require.Error(t, err, "a failed rewrite of authorized_keys must be reported")
@@ -547,7 +551,7 @@ func TestDeletePubKeyReportsReadError(t *testing.T) {
 	pk := parseTestPublicKey(t, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFxu5J1fpfRBHe/2JKreeDGgJlMZji3n97fYm3KJt8Yv sb@localhost")
 
 	user := &User{User: &osuser.User{HomeDir: t.TempDir()}}
-	user.OverrideAuthorizedKeysFilePath(t.TempDir()) // a directory, not a file
+	require.NoError(t, user.OverrideAuthorizedKeysFilePath(t.TempDir())) // a directory, not a file
 
 	err := user.DeletePubKey("ingress", pk)
 	require.Error(t, err, "a read failure must abort instead of overwriting with a truncated set")

--- a/main.go
+++ b/main.go
@@ -154,7 +154,10 @@ func main() {
 // TerminateSession is a global accessible function that terminates the session while saving the log one last time
 func TerminateSession(log *models.Log, err error) {
 	log.SessionEndDate = time.Now()
-	log.Save()
+	// Best-effort final audit write; report a failure rather than dropping it.
+	if saveErr := log.Save(); saveErr != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: unable to persist audit log: %s\n", saveErr)
+	}
 
 	var statusCode int
 	switch err {


### PR DESCRIPTION
## Summary

Enables two high-value linters for a security product — `errcheck` and `gosec` — and resolves every finding. Delivered as two commits (one per linter), each building and passing the suite independently.

### Commit 1 — `errcheck`: stop swallowing returned errors

A number of call sites discarded a returned error. Handled each at the right altitude:

- **Audit-log writes** (`Log.SetCommand/SetTargetAccess/SetAllowed/Save/insert`) are best-effort — the authorization decision is already made — so failures are logged to stderr rather than failing the command (via a small `logAuditWarn` helper and inline warnings, matching the existing `NewLog` pattern).
- **`db.AutoMigrate`** errors are now wrapped and returned from the DB-handle constructors and `Log.insert`.
- **`t.Execute`** on static, trusted templates panics, consistent with the existing panic on `template.Parse`.
- The **daemon replication goroutines** and the **ttyrec-writer goroutine** now log their errors instead of discarding them — the ttyrec case previously hid a failed session recording.
- **Flag parsing** intentionally tolerates undeclared flags (per the existing comments), so those parse errors are now explicitly ignored with a clarifying note.
- **Test** call sites assert `require.NoError`, except `SetTOTPSecret`, whose root-only `chown` is explicitly ignored (the write it performs is what the test verifies).

### Commit 2 — `gosec`: enable and justify the unavoidable findings

- **G204** (subprocess with non-literal args) is inherent to a bastion that shells out to sudo/ssh/adduser for every privileged action. `exec.Command` never invokes a shell, and user/group names are validated at the helper boundary, so it's excluded project-wide with that rationale in the config.
- **gosec on `_test.go`** is excluded (controlled local inputs trip its taint/permission heuristics).
- **Two G306** findings are public, non-secret files (a written public key; `authorized_keys`, read group-wide) that intentionally use broader-than-0600 modes — annotated inline with line-scoped `//nolint:gosec` so the rule stays active elsewhere.
- **One G602** is in a verbatim copy of x/crypto's `bcrypt_pbkdf`, where `out` is always the fixed 32 bytes the caller allocates — annotated inline rather than altering vetted crypto.

## How it's tested

`go build ./...`, `go test ./...` and `golangci-lint run` (with issue caps disabled) all pass clean at each commit.

### Reviewer checklist
- [ ] Best-effort-vs-fail-closed choice for each audit-log site is right
- [ ] Project-wide G204 exclusion (with its rationale) is acceptable, vs per-site annotation
- [ ] The four inline `//nolint:gosec` justifications hold up