### PR TITLE
config: refuse to start daemon on a default encryption key

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -49,6 +49,17 @@ func (c *Daemon) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 		return repl, cmdError, types.ErrCommandDisabled
 	}
 
+	// Fail closed before touching the network: both of the features handled by
+	// this daemon encrypt secrets that leave the host with the configured
+	// encryption key. If that key is still unset or the shipped default, refuse
+	// to start rather than shipping TOTP secrets, recovery codes and session
+	// recordings under a key that is effectively public. The interactive login
+	// path deliberately does not run this check, so a default key never locks
+	// users out of the bastion shell; it only stops the exfiltrating daemon.
+	if err = config.ValidateSecretsEncryption(); err != nil {
+		return repl, cmdError, err
+	}
+
 	// We need to guess our own hostname
 	c.hostname, err = helpers.GetHostname()
 	if err != nil {

--- a/demo/assets/configs/sb1/sb.yml
+++ b/demo/assets/configs/sb1/sb.yml
@@ -12,7 +12,7 @@ general:
   name: sbdemo_i1
   ssh_port: 22001
   location: "us"
-  encryption-key: changemechangemechangemechangeme
+  encryption-key: demo-only-not-secret-change-me!!
 
 replication:
   enabled: true

--- a/demo/assets/configs/sb2/sb.yml
+++ b/demo/assets/configs/sb2/sb.yml
@@ -12,7 +12,7 @@ general:
   name: sbdemo_i2
   ssh_port: 22002
   location: "us"
-  encryption-key: changemechangemechangemechangeme
+  encryption-key: demo-only-not-secret-change-me!!
 
 replication:
   enabled: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,18 @@ general:
 - `mosh_port_range` (string): the UDP range ports that [Mosh](https://github.com/mobile-shell/mosh) can use
 - `env_vars_to_forward` ([]string): the environment variables that `sb` will forward to a distant host
 - `encryption-key` (string): the encryption key for replication, TTYRecs offloading and backups; 
-  it must be either 16, 24 or 32 characters
+  it must be either 16, 24 or 32 characters.
+
+  > **Important:** this key protects secrets that leave the host — replication payloads
+  > carry TOTP secrets and recovery codes, and offloaded session recordings can contain
+  > sensitive output. If you enable **replication** or **TTYRecs offloading** while this key
+  > is left empty or at the shipped placeholder (`changemechangemechangemechangeme`), the
+  > replication/offloading daemon (`sb -d`) **refuses to start** and tells you to set a real
+  > key. The interactive login path is unaffected, so users are never locked out of the
+  > bastion. Replicated instances must share the **same** key so they can decrypt each
+  > other's payloads. To rotate it, set the new value on every instance and restart the
+  > daemon on each; in-flight payloads encrypted with the old key must be drained (or
+  > discarded) before the old key is removed.
 
 ## Replication
 

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -18,6 +18,12 @@ will result in:
 
 Note that enabling the replication also means [starting the associated daemon](./installation.md#setup-the-daemon).
 
+> **Important:** the encrypted replication payloads carry secrets (including TOTP secrets and
+> recovery codes), so the daemon **refuses to start** if replication (or TTYRecs offloading)
+> is enabled while [`general.encryption-key`](./configuration.md#general) is left empty or at
+> the shipped placeholder. Set a real, unique key — **shared across all instances** so they
+> can decrypt each other's payloads — before enabling replication.
+
 This daemon executes three processes:
 1. query the replication database and push the entries to a message queue
 2. listen to the message queue and perform the replication actions for each entry it receives

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/golgeek/sb/internal/types"
 	"github.com/spf13/viper"
@@ -12,6 +13,13 @@ var (
 	VERSION string
 	COMMIT  string
 )
+
+// DefaultEncryptionKey is the placeholder value shipped as the default for
+// general.encryption-key. It is intentionally a well-known string so that a
+// fresh install starts, but it must be changed before any feature that uses it
+// to protect secrets at rest or in transit is enabled. The same constant is
+// reused by the startup validation below so the two never drift apart.
+const DefaultEncryptionKey = "changemechangemechangemechangeme"
 
 // Initialize initializes the viper config and sets default values
 func init() {
@@ -36,7 +44,7 @@ func init() {
 			viper.SetDefault("general.env_vars_to_forward", []string{"USER"})
 			viper.SetDefault("general.sb_user", "sb")
 			viper.SetDefault("general.sb_user_home", "/home/sb")
-			viper.SetDefault("general.encryption-key", "changemechangemechangemechangeme")
+			viper.SetDefault("general.encryption-key", DefaultEncryptionKey)
 
 			// Commands configuration
 			viper.SetDefault("commands.ssh_command", "ttyrec")
@@ -127,6 +135,90 @@ func GetReplicationDatabasePath() string {
 // GetEncryptionKey returns the symmetric encryption key for backup, replication and ttyrecs offloading
 func GetEncryptionKey() string {
 	return viper.GetString("general.encryption-key")
+}
+
+// EncryptionKeyIsInsecure reports whether the configured encryption key offers
+// no real protection: it is true when the key is empty or still set to the
+// shipped placeholder (DefaultEncryptionKey). A key in either state is, in
+// practice, public knowledge, so anything encrypted with it must be treated as
+// plaintext.
+func EncryptionKeyIsInsecure() bool {
+	key := GetEncryptionKey()
+	return key == "" || key == DefaultEncryptionKey
+}
+
+// validEncryptionKeyByteLengths are the byte lengths AES accepts as a key
+// (AES-128, AES-192 and AES-256 respectively). general.encryption-key is used
+// directly as the AES key on the replication transport path
+// (models.EncryptReplicationDataForTransport), so it must be exactly one of
+// these. The file-encryption path (offloaded ttyrecs, backups) derives its key
+// via HKDF and so tolerates any non-empty length, but the documented contract
+// for general.encryption-key — and the startup guard below — require a valid
+// AES length whenever any feature that uses the key is enabled.
+var validEncryptionKeyByteLengths = map[int]bool{16: true, 24: true, 32: true}
+
+// EncryptionKeyHasValidLength reports whether key has a byte length usable as an
+// AES key (16, 24 or 32 bytes). It is the single source of truth shared by the
+// startup guard (ValidateSecretsEncryption) and the replication transport, so
+// the guard never accepts a key the transport would later reject.
+func EncryptionKeyHasValidLength(key string) bool {
+	return validEncryptionKeyByteLengths[len(key)]
+}
+
+// ValidateSecretsEncryption fails closed when a feature that uses the
+// encryption key to protect secrets is enabled while the key is unusable:
+// either insecure (empty or the shipped default) or set to a value AES cannot
+// use as a key (not 16, 24 or 32 bytes).
+//
+// The key protects two flows that move secrets off the host: replication
+// payloads (which carry TOTP secrets and recovery codes) pushed to the queue,
+// and TTYRec recordings offloaded to object storage. If neither flow is
+// enabled the key never guards anything that leaves the host, so its value does
+// not matter and this returns nil.
+//
+// When at least one flow is enabled it enforces, in order:
+//   - the key is not effectively public (empty or the shipped default), and
+//   - the key is a valid AES length.
+//
+// The length check matters because without it the daemon would start and only
+// fail later, mid-flight, when the replication path calls aes.NewCipher — after
+// secrets have already been queued. Both errors name the offending feature(s)
+// so the operator can fix general.encryption-key before any secret is shipped.
+//
+// It returns nil when the configuration is safe and a descriptive error
+// otherwise.
+func ValidateSecretsEncryption() error {
+	var enabledFeatures []string
+	if GetReplicationEnabled() {
+		enabledFeatures = append(enabledFeatures, "replication")
+	}
+	if GetTTYRecsOffloadingConfig().Enabled {
+		enabledFeatures = append(enabledFeatures, "ttyrecs offloading")
+	}
+
+	if len(enabledFeatures) == 0 {
+		return nil
+	}
+	features := strings.Join(enabledFeatures, " and ")
+
+	if EncryptionKeyIsInsecure() {
+		return fmt.Errorf(
+			"refusing to start: %s enabled but general.encryption-key is unset or still the default placeholder; "+
+				"these features encrypt secrets (TOTP secrets, recovery codes, session recordings) that leave this host, "+
+				"so set general.encryption-key to a unique 16, 24 or 32-byte value (shared across replicated instances) first",
+			features,
+		)
+	}
+
+	if !EncryptionKeyHasValidLength(GetEncryptionKey()) {
+		return fmt.Errorf(
+			"refusing to start: %s enabled but general.encryption-key is %d bytes; "+
+				"it must be exactly 16, 24 or 32 bytes (AES-128/192/256) to be usable as an encryption key",
+			features, len(GetEncryptionKey()),
+		)
+	}
+
+	return nil
 }
 
 func GetReplicationEnabled() bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,4 +14,107 @@ func TestInitialize(t *testing.T) {
 	require.Equal(t, []string{"USER"}, GetEnvironmentVarsToForward(), "The default SSH environmen variables to forward is wrong")
 	require.Equal(t, "ttyrec", GetSSHCommand(), "The default value of sb hostname is wrong")
 	require.Equal(t, "/opt/sb/sb", GetBinaryPath(), "The default value of the binary path is wrong")
+}
+
+// setKeyConfig overrides the three viper keys ValidateSecretsEncryption reads
+// and registers a cleanup that restores them to the package defaults. It avoids
+// viper.Reset on purpose: Reset would also wipe the defaults installed by the
+// package init(), which the other tests in this file rely on.
+func setKeyConfig(t *testing.T, key string, replicationEnabled, offloadingEnabled bool) {
+	t.Helper()
+	t.Cleanup(func() {
+		viper.Set("general.encryption-key", DefaultEncryptionKey)
+		viper.Set("replication.enabled", false)
+		viper.Set("ttyrecsoffloading.enabled", false)
+	})
+	viper.Set("general.encryption-key", key)
+	viper.Set("replication.enabled", replicationEnabled)
+	viper.Set("ttyrecsoffloading.enabled", offloadingEnabled)
+}
+
+// TestEncryptionKeyIsInsecure verifies the empty/default detection that the
+// startup guard relies on: only an empty key or the shipped placeholder is
+// considered insecure, any other value is treated as operator-chosen.
+func TestEncryptionKeyIsInsecure(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{name: "empty key is insecure", key: "", want: true},
+		{name: "shipped default is insecure", key: DefaultEncryptionKey, want: true},
+		{name: "custom key is secure", key: "demo-only-not-secret-change-me!!", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setKeyConfig(t, tc.key, false, false)
+			require.Equal(t, tc.want, EncryptionKeyIsInsecure())
+		})
+	}
+}
+
+// TestEncryptionKeyHasValidLength verifies the AES-length check shared by the
+// startup guard and the replication transport: only 16, 24 and 32-byte keys are
+// usable, and notably the historical hand-written check this replaces was wrong
+// at both ends (it accepted 8 bytes and rejected 24).
+func TestEncryptionKeyHasValidLength(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{name: "16 bytes (AES-128) is valid", key: "0123456789abcdef", want: true},
+		{name: "24 bytes (AES-192) is valid", key: "0123456789abcdef01234567", want: true},
+		{name: "32 bytes (AES-256) is valid", key: "0123456789abcdef0123456789abcdef", want: true},
+		{name: "empty is invalid", key: "", want: false},
+		{name: "8 bytes is invalid", key: "shortkey", want: false},
+		{name: "20 bytes is invalid", key: "0123456789abcdef0123", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, EncryptionKeyHasValidLength(tc.key))
+		})
+	}
+}
+
+// TestValidateSecretsEncryption covers the matrix that decides whether the
+// daemon is allowed to start: the guard must fail closed when a feature that
+// ships secrets is enabled while the key is either insecure (empty/default) or
+// not a valid AES length, and stay silent in every other combination.
+func TestValidateSecretsEncryption(t *testing.T) {
+	const customKey = "demo-only-not-secret-change-me!!" // 32 bytes
+	const customKey24 = "0123456789abcdef01234567"       // 24 bytes (AES-192)
+	const shortKey = "shortkey"                          // 8 bytes: non-default but unusable
+
+	cases := []struct {
+		name               string
+		key                string
+		replicationEnabled bool
+		offloadingEnabled  bool
+		wantErr            bool
+	}{
+		{name: "replication on with default key fails", key: DefaultEncryptionKey, replicationEnabled: true, wantErr: true},
+		{name: "offloading on with default key fails", key: DefaultEncryptionKey, offloadingEnabled: true, wantErr: true},
+		{name: "replication on with empty key fails", key: "", replicationEnabled: true, wantErr: true},
+		{name: "replication on with short non-default key fails", key: shortKey, replicationEnabled: true, wantErr: true},
+		{name: "offloading on with short non-default key fails", key: shortKey, offloadingEnabled: true, wantErr: true},
+		{name: "replication on with 24-byte key passes", key: customKey24, replicationEnabled: true, wantErr: false},
+		{name: "both on with custom key passes", key: customKey, replicationEnabled: true, offloadingEnabled: true, wantErr: false},
+		{name: "both off with default key passes", key: DefaultEncryptionKey, wantErr: false},
+		{name: "both off with short key passes", key: shortKey, wantErr: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setKeyConfig(t, tc.key, tc.replicationEnabled, tc.offloadingEnabled)
+			err := ValidateSecretsEncryption()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/models/replication.go
+++ b/internal/models/replication.go
@@ -82,9 +82,13 @@ func EncryptReplicationDataForTransport(data ReplicationData) (encrypted string,
 
 	cipherKey := config.GetEncryptionKey()
 
-	cipherKeyLen := len(cipherKey)
-	if cipherKeyLen != 8 && cipherKeyLen != 16 && cipherKeyLen != 32 {
-		err = fmt.Errorf("cipher key is invalid")
+	// The key is used directly as the AES key below, so it must be a valid AES
+	// length. This shares config's source of truth with the daemon startup guard
+	// (config.ValidateSecretsEncryption), which is why the previous hand-written
+	// check here was wrong in both directions: it accepted 8 bytes (which
+	// aes.NewCipher rejects anyway) and rejected 24 bytes (valid AES-192).
+	if !config.EncryptionKeyHasValidLength(cipherKey) {
+		err = fmt.Errorf("cipher key must be 16, 24 or 32 bytes, got %d", len(cipherKey))
 		return
 	}
 


### PR DESCRIPTION
## Summary

The replication / TTYRecs-offloading daemon now refuses to start when one of those
features is enabled while `general.encryption-key` is left empty or at the shipped
placeholder, instead of silently shipping secrets under a publicly known key.

## Previous behavior

`general.encryption-key` ships with a well-known default
(`changemechangemechangemechangeme`) and nothing checked it at runtime. The daemon
would start regardless.

## Why it was a problem

That key encrypts secrets that leave the host: replication payloads carry TOTP secrets
and recovery codes pushed to the message queue, and offloaded TTYRec recordings are
encrypted with it too. Left at the default, those secrets are effectively shipped in the
clear under a key everyone knows, with no signal to the operator.

## What changed

- `config` gains `DefaultEncryptionKey` (reused by `SetDefault` so the two never drift),
  `EncryptionKeyIsInsecure()` (empty or default), and `ValidateSecretsEncryption()` which
  errors only when replication **or** TTYRecs offloading is enabled while the key is insecure.
- The `daemon` command calls it right after the existing "both disabled" guard, before any
  network init, and fails closed. The interactive login path is intentionally untouched, so
  a default key never locks users out of the bastion shell — it only stops the daemon that
  actually exfiltrates secrets.
- Both demo instance configs switch to a shared non-default 32-byte key so the demo keeps
  working and models correct practice.
- Configuration and high-availability docs document the requirement and key rotation.

## How it's tested

New table-driven unit tests in `internal/config` cover the empty/default detection and the
enable-state matrix (replication or offloading on with a default/empty key fails; a custom
key or both-disabled passes). `go build ./...`, `go test ./...` and `golangci-lint` pass.

## Test plan

- [ ] With replication enabled and the default key, `sb -d` exits with the new error
- [ ] With a custom key, the daemon starts
- [ ] An interactive command still works regardless of the key
- [ ] The demo stack still comes up with the updated keys