### PR TITLE
cmd: pin egress host-key verification

### DIFF
--- a/cmd/egress_hostkey_test.go
+++ b/cmd/egress_hostkey_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/golgeek/sb/internal/models"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestScpBuildEgressBaseCommand asserts the SCP egress prefix pins host-key
+// verification explicitly: it must carry the user's managed known_hosts file
+// and the requested StrictHostKeyChecking policy, alongside the existing
+// hardening options, port, login user and each private key. It deliberately
+// stops before the "-- host <command>" tail so both legacy and SFTP modes can
+// reuse it.
+func TestScpBuildEgressBaseCommand(t *testing.T) {
+	c := new(Scp)
+	access := &models.Access{Host: "prod-web", User: "deploy", Port: 2222}
+
+	cmd := c.buildEgressBaseCommand(
+		"/usr/bin/ssh", access,
+		[]string{"/home/alice/.ssh/id_a", "/home/alice/.ssh/id_b"},
+		"/home/alice/.ssh/known_hosts", "accept-new",
+	)
+
+	require.Equal(t, "/usr/bin/ssh", cmd[0])
+	require.Contains(t, cmd, "-oUserKnownHostsFile=/home/alice/.ssh/known_hosts")
+	require.Contains(t, cmd, "-oStrictHostKeyChecking=accept-new")
+	require.Contains(t, cmd, "-oForwardAgent=no")
+	require.Subset(t, cmd, []string{"-p", "2222"})
+	require.Subset(t, cmd, []string{"-l", "deploy"})
+	require.Subset(t, cmd, []string{"-i", "/home/alice/.ssh/id_a"})
+	require.Subset(t, cmd, []string{"-i", "/home/alice/.ssh/id_b"})
+
+	// The transparent transfer tail is the caller's responsibility, so the host
+	// must not yet be present in the base command.
+	require.NotContains(t, cmd, "prod-web")
+}
+
+// TestTtyrecBuildSSHCommand asserts the interactive egress command pins host-key
+// verification while keeping agent forwarding enabled for onward auth.
+func TestTtyrecBuildSSHCommand(t *testing.T) {
+	if _, err := exec.LookPath("ssh"); err != nil {
+		t.Skip("ssh not available on this system")
+	}
+
+	c := new(Ttyrec)
+	access := &models.Access{Host: "prod-db", User: "root", Port: 22}
+
+	cmd, err := c.buildSSHCommand(
+		access,
+		[]string{"/home/bob/.ssh/id_x"},
+		nil,
+		"/home/bob/.ssh/known_hosts", "yes",
+	)
+	require.NoError(t, err)
+
+	require.Contains(t, cmd, "-oUserKnownHostsFile=/home/bob/.ssh/known_hosts")
+	require.Contains(t, cmd, "-oStrictHostKeyChecking=yes")
+	require.Contains(t, cmd, "-A")
+	require.Subset(t, cmd, []string{"-i", "/home/bob/.ssh/id_x"})
+}

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -122,28 +123,23 @@ func (c *Scp) Execute(ct *commands.Context) (repl models.ReplicationData, cmdErr
 		return
 	}
 
-	command := []string{
-		sshPath,
-		"-x",
-		"-oForwardAgent=no",
-		"-oPermitLocalCommand=no",
-		"-oClearAllForwardings=yes",
-		"-p", strconv.Itoa(access.Port),
-		"-l", access.User,
-	}
-	for _, privateKeyFile := range ct.AI.KeyFilepathes {
-		command = append(command, "-i", privateKeyFile)
-	}
+	// Build the egress command prefix (ssh options + port/user/keys, with
+	// host-key verification pinned), then append the transparent transfer tail.
+	command := c.buildEgressBaseCommand(sshPath, access, ct.AI.KeyFilepathes, ct.User.GetKnownHostsFilepath(), config.GetEgressStrictHostKeyChecking())
 	command = append(command,
 		"--",
 		access.Host,
 		ct.FormattedArguments["scp-cmd"],
 	)
 
+	// Watch the egress stderr for a host-key mismatch so we can surface a
+	// recovery hint; it shadows os.Stderr and does not alter the real output.
+	hostKeyWatcher := &helpers.HostKeyWatcher{}
+
 	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = io.MultiWriter(os.Stderr, hostKeyWatcher)
 
 	err = cmd.Start()
 	if err != nil {
@@ -160,7 +156,46 @@ func (c *Scp) Execute(ct *commands.Context) (repl models.ReplicationData, cmdErr
 		err = nil
 	}
 
+	// If the host key changed, point the user at the forget command (gated on trust).
+	if hostKeyWatcher.Triggered() {
+		fmt.Fprint(os.Stderr, helpers.HostKeyMismatchHint(
+			ct.User.User.Username, config.GetSBHostname(), config.GetSSHPort(),
+			access.Host, access.Port,
+		))
+	}
+
 	return
+}
+
+// buildEgressBaseCommand assembles the common prefix of the egress SSH command
+// used to proxy a transfer to a distant host: the ssh binary, the hardening
+// options (agent forwarding off, no local command, all forwardings cleared),
+// pinned host-key verification against the user's managed known_hosts with the
+// configured policy, the target port and login user, and each private key.
+//
+// It deliberately stops before the "-- host <command>" tail so callers can
+// append either the legacy "scp -t/-f" command or, in SFTP mode, an sftp
+// subsystem request, keeping a single place that owns the security-relevant
+// options. The returned slice's first element is sshPath.
+func (c *Scp) buildEgressBaseCommand(sshPath string, access *models.Access, keyFiles []string, knownHostsFile, strictHostKeyChecking string) []string {
+	// 11 fixed elements (ssh path, the hardening/host-key options, -p/-l pairs)
+	// plus two entries per private key.
+	command := make([]string, 0, 11+2*len(keyFiles))
+	command = append(command,
+		sshPath,
+		"-x",
+		"-oForwardAgent=no",
+		"-oPermitLocalCommand=no",
+		"-oClearAllForwardings=yes",
+		fmt.Sprintf("-oUserKnownHostsFile=%s", knownHostsFile),
+		fmt.Sprintf("-oStrictHostKeyChecking=%s", strictHostKeyChecking),
+		"-p", strconv.Itoa(access.Port),
+		"-l", access.User,
+	)
+	for _, privateKeyFile := range keyFiles {
+		command = append(command, "-i", privateKeyFile)
+	}
+	return command
 }
 
 func (c *Scp) PostExecute(repl models.ReplicationData) (err error) {

--- a/cmd/ttyrec.go
+++ b/cmd/ttyrec.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/golgeek/sb/internal/commands"
 	"github.com/golgeek/sb/internal/config"
@@ -22,6 +23,25 @@ import (
 
 // Ttyrec describes the ttyrec command
 type Ttyrec struct{}
+
+// lockedWriter serializes writes to an underlying writer behind a mutex. The
+// session's stdout and stderr are drained by two separate goroutines that both
+// record into the same ttyrec.Encoder, which is not safe for concurrent use; a
+// lockedWriter wrapping the encoder makes each frame write atomic so the two
+// streams can be recorded as they arrive without corrupting the recording.
+type lockedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// Write forwards p to the wrapped writer while holding the mutex, so concurrent
+// callers never interleave a single frame. It returns the wrapped writer's
+// result unchanged.
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}
 
 func init() {
 	commands.RegisterCommand("ttyrec", func() (c commands.Command, r models.Right, h helpers.Helper, args map[string]commands.Argument) {
@@ -74,8 +94,11 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 		"ttyrec-record-path": fmt.Sprintf("%s/%s.ttyrec", ct.User.GetTtyrecDirectory(), ct.Log.UniqID),
 	}
 
-	// Building the SSH command
-	sshCommand, err := c.buildSSHCommand(access, ct.AI.KeyFilepathes, ct.RawArguments)
+	// Building the SSH command. The egress hop pins host-key verification
+	// against the user's managed known_hosts with the configured policy
+	// (TOFU-with-pinning by default), so the session and the forwarded agent are
+	// never silently exposed to a host whose key has changed.
+	sshCommand, err := c.buildSSHCommand(access, ct.AI.KeyFilepathes, ct.RawArguments, ct.User.GetKnownHostsFilepath(), config.GetEgressStrictHostKeyChecking())
 	if err != nil {
 		return
 	}
@@ -112,30 +135,26 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 	}
 	defer stderr.Close()
 
-	// Handle ttyrec to a file. This runs in its own goroutine, so it cannot return
-	// an error to the caller; it logs any failure to stderr instead of dropping it
-	// silently, which previously hid a failed session recording.
-	go func(filename string, r io.Reader) {
+	// Watch the egress stderr for a host-key-mismatch so we can hand the user a
+	// recovery hint after the connection is refused. It is one leg of the stderr
+	// fan-out below, so the real error output is unaffected.
+	hostKeyWatcher := &helpers.HostKeyWatcher{}
 
-		f, err := os.Create(filename)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: unable to open ttyrec file: %s\n", err)
-			return
-		}
+	// Open the recording file up front so a failure is reported immediately
+	// rather than from inside a goroutine. Recording is best-effort: if the file
+	// cannot be created we still run a live session, writing the recording to
+	// io.Discard, so a recording problem never blocks the user's connection.
+	// Both stream copiers below share this single encoder, serialized by
+	// lockedWriter because ttyrec.Encoder is not safe for concurrent use.
+	// io.Discard is typed io.Writer, so rec stays an io.Writer that the
+	// successful branch can reassign to the recording encoder.
+	rec := io.Discard
+	if f, ferr := os.Create(repl["ttyrec-record-path"]); ferr != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: unable to open ttyrec file: %s\n", ferr)
+	} else {
 		defer f.Close()
-
-		e := ttyrec.NewEncoder(f)
-
-		if _, err := io.Copy(e, r); err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: unable to write SSH session to ttyrec: %s\n", err)
-		}
-	}(
-		repl["ttyrec-record-path"],
-		io.MultiReader(
-			io.TeeReader(stdout, os.Stdout),
-			io.TeeReader(stderr, os.Stderr),
-		),
-	)
+		rec = &lockedWriter{w: ttyrec.NewEncoder(f)}
+	}
 
 	// Start the command
 	err = cmd.Start()
@@ -143,6 +162,39 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 		err = fmt.Errorf("unable to start command: %w", err)
 		return
 	}
+
+	// Drain stdout and stderr CONCURRENTLY, each in its own goroutine. The
+	// previous implementation wrapped both pipes in a single io.MultiReader,
+	// which reads stdout to EOF — i.e. until the egress process exits — before it
+	// ever touches stderr. ssh writes its own diagnostics (host-key mismatch,
+	// "Permission denied", connection errors) to stderr, so that ordering hid
+	// every error from the user until the session was already over, starved the
+	// host-key watcher of its input until shutdown, and recorded all of stderr
+	// appended after all of stdout instead of in the order they actually
+	// occurred. Copying each stream independently forwards errors to the terminal
+	// the instant ssh emits them and records frames in true arrival order. Each
+	// stream fans out to the terminal and the recorder; stderr additionally feeds
+	// the host-key watcher.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if _, cerr := io.Copy(io.MultiWriter(os.Stdout, rec), stdout); cerr != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: unable to record session stdout: %s\n", cerr)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if _, cerr := io.Copy(io.MultiWriter(os.Stderr, hostKeyWatcher, rec), stderr); cerr != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: unable to record session stderr: %s\n", cerr)
+		}
+	}()
+
+	// Both pipes reach EOF when the egress process closes them (i.e. when it
+	// exits), so this returns once the session output is fully drained and
+	// scanned — which must happen before Wait closes the pipes out from under
+	// the readers.
+	wg.Wait()
 
 	// Wait until user exits the shell
 	err = cmd.Wait()
@@ -162,6 +214,15 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 
 	if cmd.ProcessState.ExitCode() > 0 {
 		cmdError = fmt.Errorf("failed to execute command on distant host: %w", cmdError)
+	}
+
+	// If the connection was refused because the distant host's key changed, give
+	// the user a copy-pasteable command to clear the stale pin (gated on trust).
+	if hostKeyWatcher.Triggered() {
+		fmt.Fprint(os.Stderr, helpers.HostKeyMismatchHint(
+			ct.User.User.Username, config.GetSBHostname(), config.GetSSHPort(),
+			access.Host, access.Port,
+		))
 	}
 
 	return
@@ -265,7 +326,7 @@ func (c *Ttyrec) buildMOSHCommand(clientArguments string) (cmd []string, err err
 	return
 }
 
-func (c *Ttyrec) buildSSHCommand(access *models.Access, keyfilePathes []string, rawArguments []string) (cmd []string, err error) {
+func (c *Ttyrec) buildSSHCommand(access *models.Access, keyfilePathes []string, rawArguments []string, knownHostsFile, strictHostKeyChecking string) (cmd []string, err error) {
 
 	// Set sb environment
 	for _, envVar := range config.GetEnvironmentVarsToForward() {
@@ -279,12 +340,19 @@ func (c *Ttyrec) buildSSHCommand(access *models.Access, keyfilePathes []string, 
 		return
 	}
 
-	// Building the ssh command
+	// Building the ssh command. Host-key verification is pinned explicitly
+	// rather than left to inherited ssh defaults: -oUserKnownHostsFile points at
+	// the user's managed known_hosts and -oStrictHostKeyChecking carries the
+	// configured policy (accept-new by default: pin on first sight, refuse a
+	// later changed key). -A keeps agent forwarding for onward auth from the
+	// distant host.
 	cmd = []string{
 		sshPath, access.Host,
 		"-l", access.User,
 		"-p", fmt.Sprintf("%d", access.Port),
 		"-A",
+		fmt.Sprintf("-oUserKnownHostsFile=%s", knownHostsFile),
+		fmt.Sprintf("-oStrictHostKeyChecking=%s", strictHostKeyChecking),
 	}
 
 	// We push environment variables to forward

--- a/cmd/ttyrec_test.go
+++ b/cmd/ttyrec_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLockedWriterSerializesConcurrentWrites verifies that lockedWriter makes
+// concurrent writes to a shared, non-thread-safe writer safe: the stdout and
+// stderr copiers in Ttyrec.Execute both record into one ttyrec.Encoder through
+// a lockedWriter, so every byte written by every goroutine must reach the
+// underlying writer exactly once with no interleaving within a single Write.
+// Run under `go test -race` this also asserts there is no data race on the
+// shared writer.
+func TestLockedWriterSerializesConcurrentWrites(t *testing.T) {
+	var underlying bytes.Buffer
+	lw := &lockedWriter{w: &underlying}
+
+	const writers = 8
+	const writesPerWriter = 200
+	// Each writer emits a distinct, fixed-size frame so we can both count total
+	// bytes and confirm no frame was split by an interleaving write.
+	frame := []byte("0123456789ABCDEF")
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for range writers {
+		go func() {
+			defer wg.Done()
+			for range writesPerWriter {
+				n, err := lw.Write(frame)
+				require.NoError(t, err)
+				require.Equal(t, len(frame), n)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got := underlying.Bytes()
+	require.Len(t, got, writers*writesPerWriter*len(frame))
+
+	// Because each Write is atomic under the lock, the output must be an exact
+	// concatenation of whole frames — every aligned slice equals the frame.
+	for off := 0; off < len(got); off += len(frame) {
+		require.True(t, bytes.Equal(got[off:off+len(frame)], frame),
+			"frame at offset %d was corrupted by an interleaved write", off)
+	}
+}
+
+// TestLockedWriterPropagatesError confirms lockedWriter returns the underlying
+// writer's error unchanged, so a recording failure is surfaced rather than
+// swallowed.
+func TestLockedWriterPropagatesError(t *testing.T) {
+	lw := &lockedWriter{w: errWriter{}}
+	_, err := lw.Write([]byte("x"))
+	require.ErrorIs(t, err, errWrite)
+}
+
+// errWriter is an io.Writer that always fails, used to check error propagation.
+type errWriter struct{}
+
+var errWrite = io.ErrShortWrite
+
+func (errWriter) Write([]byte) (int, error) { return 0, errWrite }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ general:
   mosh_ports_range: 40000:49999
   env_vars_to_forward: ["USER"]
   encryption-key: changemechangemechangemechangeme
+  egress_strict_host_key_checking: accept-new
 ```
 
 - `binary_path` (string): the path where `sb`'s binary is on the bastion server
@@ -52,6 +53,11 @@ general:
   > other's payloads. To rotate it, set the new value on every instance and restart the
   > daemon on each; in-flight payloads encrypted with the old key must be drained (or
   > discarded) before the old key is removed.
+- `egress_strict_host_key_checking` (string): the `StrictHostKeyChecking` policy used on the
+  egress hop (bastion → distant host) for both interactive sessions and SCP. Defaults to
+  `accept-new` (pin a host's key on first sight, refuse a later change); set to `yes` to
+  refuse any host not already pinned, or `no` to disable verification (discouraged). See
+  [egress host-key verification](./usage.md#egress-host-key-verification)
 
 ## Replication
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -162,6 +162,33 @@ Available commands:
   - self totp enable                   : enable TOTP on the account
 ```
 
+## Egress host-key verification
+
+When `sb` connects you to a distant host (interactive sessions and SCP alike), it pins the
+host-key check on that bastion → host hop instead of relying on inherited SSH defaults. Each
+distant host key is recorded in your managed `known_hosts` on the bastion, and the policy is
+controlled by `general.egress_strict_host_key_checking`
+([configuration](./configuration.md#general)):
+
+- `accept-new` (default): the first time a host is seen, its key is pinned automatically;
+  if a pinned host later presents a **different** key, the connection is refused
+  (trust-on-first-use with pinning). This protects the session — and the forwarded agent —
+  from a host whose key has changed.
+- `yes`: refuse any host that is not already pinned (use this if you provision host keys out
+  of band).
+- `no`: disable verification entirely (strongly discouraged).
+
+If a connection is refused because a host key changed, `sb` prints a ready-to-paste command
+that clears the stale pin via `self hostkey forget`. **Only run it if you trust the change**
+(e.g. the host was legitimately rebuilt) — a key change can also be a man-in-the-middle
+attack:
+
+```console
+t1000@skynet:~# ssh -p 22 t1000@sb.YOUR_DOMAIN.com "self hostkey forget --hostkey '10.0.0.10'"
+```
+
+Then reconnect; the new key is pinned on the next connection.
+
 ## Use SCP across sb
 
 If your goal is to transfer files from or to a distant host with `scp` through `sb`, you're in luck!

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ func init() {
 			viper.SetDefault("general.sb_user", "sb")
 			viper.SetDefault("general.sb_user_home", "/home/sb")
 			viper.SetDefault("general.encryption-key", DefaultEncryptionKey)
+			viper.SetDefault("general.egress_strict_host_key_checking", defaultEgressStrictHostKeyChecking)
 
 			// Commands configuration
 			viper.SetDefault("commands.ssh_command", "ttyrec")
@@ -219,6 +220,34 @@ func ValidateSecretsEncryption() error {
 	}
 
 	return nil
+}
+
+// defaultEgressStrictHostKeyChecking is the fallback host-key policy for the
+// egress hop. It is also registered with viper.SetDefault, but that default only
+// applies when sb runs with no config file at all; real deployments always have
+// one, so the accessor below must not depend on it.
+const defaultEgressStrictHostKeyChecking = "accept-new"
+
+// GetEgressStrictHostKeyChecking returns the value passed to the egress SSH
+// hop's -oStrictHostKeyChecking option (bastion -> distant host).
+//
+// It defaults to "accept-new": the first time a distant host is seen its key is
+// pinned in the user's managed known_hosts, and any later key change is refused
+// (TOFU-with-pinning). Operators who pre-provision host keys out of band can
+// tighten this to "yes" to refuse any unknown host; "no" disables verification
+// entirely and is strongly discouraged. The value is passed verbatim to ssh.
+//
+// An empty value is treated as unset and falls back to the default. This is
+// deliberate: viper's SetDefault only takes effect when no config file is
+// present, but existing deployments have a config file that predates this key,
+// so the value would be empty there — and emitting "-oStrictHostKeyChecking="
+// makes ssh abort with "no argument after keyword". Falling back here keeps
+// those deployments working and never produces an empty option.
+func GetEgressStrictHostKeyChecking() string {
+	if policy := viper.GetString("general.egress_strict_host_key_checking"); policy != "" {
+		return policy
+	}
+	return defaultEgressStrictHostKeyChecking
 }
 
 func GetReplicationEnabled() bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,3 +118,24 @@ func TestValidateSecretsEncryption(t *testing.T) {
 		})
 	}
 }
+
+// TestGetEgressStrictHostKeyChecking verifies the accessor never returns an
+// empty policy (which would make ssh abort with "no argument after keyword
+// stricthostkeychecking"). A configured value is returned verbatim, while an
+// empty/unset value — the situation for deployments whose config file predates
+// this key, since viper defaults do not apply when a config file is present —
+// falls back to the safe default.
+func TestGetEgressStrictHostKeyChecking(t *testing.T) {
+	t.Cleanup(func() { viper.Set("general.egress_strict_host_key_checking", defaultEgressStrictHostKeyChecking) })
+
+	t.Run("configured value is returned", func(t *testing.T) {
+		viper.Set("general.egress_strict_host_key_checking", "yes")
+		require.Equal(t, "yes", GetEgressStrictHostKeyChecking())
+	})
+
+	t.Run("empty value falls back to the default", func(t *testing.T) {
+		viper.Set("general.egress_strict_host_key_checking", "")
+		require.Equal(t, defaultEgressStrictHostKeyChecking, GetEgressStrictHostKeyChecking())
+		require.NotEmpty(t, GetEgressStrictHostKeyChecking())
+	})
+}

--- a/internal/helpers/hostkey.go
+++ b/internal/helpers/hostkey.go
@@ -1,0 +1,102 @@
+package helpers
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// hostKeyMismatchMarkers are the distinctive strings OpenSSH prints to stderr
+// when an egress connection is refused because the distant host presented a key
+// that does not match the one pinned in known_hosts (StrictHostKeyChecking
+// catching a changed key). Matching on these lets us surface a recovery hint to
+// the user instead of leaving them with a raw, scary ssh error.
+var hostKeyMismatchMarkers = [][]byte{
+	[]byte("REMOTE HOST IDENTIFICATION HAS CHANGED"),
+	[]byte("Host key verification failed"),
+}
+
+// hostKeyWatcherTailLen is the number of trailing bytes the watcher retains
+// between writes so that a marker split across two Write calls is still found.
+// It is comfortably larger than the longest marker above.
+const hostKeyWatcherTailLen = 256
+
+// HostKeyWatcher is an io.Writer meant to be tee'd alongside the egress SSH
+// process's stderr. It scans the byte stream for the host-key-mismatch markers
+// without buffering the whole (potentially large) stream: it keeps only a small
+// trailing window between writes so markers straddling a write boundary are
+// still detected. Once a marker is seen it latches Triggered to true and stops
+// scanning. Write never errors, so it never interferes with the real stderr
+// copy it shadows.
+type HostKeyWatcher struct {
+	triggered bool
+	tail      []byte
+}
+
+// Write scans p (combined with the retained tail) for any mismatch marker and
+// latches the triggered state. It always reports the full length as written and
+// a nil error so it is safe to use as one leg of an io.MultiWriter shadowing
+// the real stderr.
+func (w *HostKeyWatcher) Write(p []byte) (n int, err error) {
+	if !w.triggered {
+		scan := make([]byte, 0, len(w.tail)+len(p))
+		scan = append(scan, w.tail...)
+		scan = append(scan, p...)
+
+		for _, marker := range hostKeyMismatchMarkers {
+			if bytes.Contains(scan, marker) {
+				w.triggered = true
+				w.tail = nil
+				break
+			}
+		}
+
+		if !w.triggered {
+			// Retain only the trailing window for the next write so a marker
+			// spanning the boundary is still caught, keeping memory bounded.
+			if len(scan) > hostKeyWatcherTailLen {
+				scan = scan[len(scan)-hostKeyWatcherTailLen:]
+			}
+			w.tail = append(w.tail[:0], scan...)
+		}
+	}
+	return len(p), nil
+}
+
+// Triggered reports whether a host-key-mismatch marker has been seen so far.
+func (w *HostKeyWatcher) Triggered() bool {
+	return w.triggered
+}
+
+// knownHostsToken returns the token that identifies the distant host in a
+// known_hosts file, matching how OpenSSH stores and how `ssh-keygen -R` removes
+// it: a bare hostname for the default SSH port (22), or the bracketed
+// "[host]:port" form for any non-standard port.
+func knownHostsToken(host string, port int) string {
+	if port == 22 {
+		return host
+	}
+	return fmt.Sprintf("[%s]:%d", host, port)
+}
+
+// HostKeyMismatchHint builds the message shown to a user whose egress
+// connection was refused because the distant host's key changed since it was
+// pinned. It explains the situation and hands back a ready-to-paste command
+// (run from the user's own machine, back through this bastion) that clears the
+// stale pin via the existing "self hostkey forget" command, gated behind an
+// explicit "only if you trust this change" warning so a real man-in-the-middle
+// is not waved through.
+//
+//	sbUser/sbHost/sbPort describe how the user reaches this bastion.
+//	targetHost/targetPort describe the distant host that failed verification.
+func HostKeyMismatchHint(sbUser, sbHost, sbPort, targetHost string, targetPort int) string {
+	token := knownHostsToken(targetHost, targetPort)
+	return fmt.Sprintf(`
+⚠ Host key verification FAILED for %s: the host key changed since it was pinned.
+  This can be a legitimate host rebuild/rekey — or a man-in-the-middle attack.
+  ONLY if you trust this change, clear the stored key by running from your machine:
+
+      ssh -p %s %s@%s "self hostkey forget --hostkey '%s'"
+
+  then reconnect. Do NOT run it if you did not expect the host key to change.
+`, token, sbPort, sbUser, sbHost, token)
+}

--- a/internal/helpers/hostkey_test.go
+++ b/internal/helpers/hostkey_test.go
@@ -1,0 +1,81 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHostKeyWatcher exercises the streaming detector: it must latch on either
+// OpenSSH mismatch marker, find a marker even when it is split across two
+// writes, and stay quiet on benign output.
+func TestHostKeyWatcher(t *testing.T) {
+	t.Run("detects changed-identification banner", func(t *testing.T) {
+		w := &HostKeyWatcher{}
+		_, _ = w.Write([]byte("@@@@@@@@@@\nWARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!\n"))
+		if !w.Triggered() {
+			t.Fatal("expected watcher to trigger on the changed-identification banner")
+		}
+	})
+
+	t.Run("detects verification-failed line", func(t *testing.T) {
+		w := &HostKeyWatcher{}
+		_, _ = w.Write([]byte("Host key verification failed.\r\n"))
+		if !w.Triggered() {
+			t.Fatal("expected watcher to trigger on the verification-failed line")
+		}
+	})
+
+	t.Run("detects a marker split across writes", func(t *testing.T) {
+		w := &HostKeyWatcher{}
+		_, _ = w.Write([]byte("Host key verifi"))
+		_, _ = w.Write([]byte("cation failed."))
+		if !w.Triggered() {
+			t.Fatal("expected watcher to trigger on a marker spanning two writes")
+		}
+	})
+
+	t.Run("ignores benign output", func(t *testing.T) {
+		w := &HostKeyWatcher{}
+		_, _ = w.Write([]byte("Welcome to the distant host\nlast login: yesterday\n"))
+		if w.Triggered() {
+			t.Fatal("did not expect the watcher to trigger on benign output")
+		}
+	})
+
+	t.Run("write reports full length and no error", func(t *testing.T) {
+		w := &HostKeyWatcher{}
+		payload := []byte("some bytes")
+		n, err := w.Write(payload)
+		if err != nil {
+			t.Fatalf("Write returned an error: %s", err)
+		}
+		if n != len(payload) {
+			t.Fatalf("Write reported %d bytes, want %d", n, len(payload))
+		}
+	})
+}
+
+// TestHostKeyMismatchHint checks that the recovery hint embeds a copy-pasteable
+// forget command with the correct known_hosts token: a bare host on port 22 and
+// the bracketed [host]:port form otherwise.
+func TestHostKeyMismatchHint(t *testing.T) {
+	t.Run("default port uses bare host token", func(t *testing.T) {
+		hint := HostKeyMismatchHint("alice", "bastion.example.com", "22", "prod-web", 22)
+		if !strings.Contains(hint, "self hostkey forget --hostkey 'prod-web'") {
+			t.Fatalf("hint missing bare-host forget command:\n%s", hint)
+		}
+		if !strings.Contains(hint, "ssh -p 22 alice@bastion.example.com") {
+			t.Fatalf("hint missing bastion ssh invocation:\n%s", hint)
+		}
+	})
+
+	t.Run("non-default port uses bracketed token", func(t *testing.T) {
+		hint := HostKeyMismatchHint("alice", "bastion.example.com", "2222", "prod-db", 2022)
+		if !strings.Contains(hint, "self hostkey forget --hostkey '[prod-db]:2022'") {
+			t.Fatalf("hint missing bracketed forget command:\n%s", hint)
+		}
+		if !strings.Contains(hint, "ssh -p 2222 alice@bastion.example.com") {
+			t.Fatalf("hint missing bastion ssh invocation with custom port:\n%s", hint)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The egress SSH hop (bastion → distant host) for both interactive sessions and SCP now pins
host-key verification explicitly against the user's managed `known_hosts`, instead of
relying on inherited ssh defaults. On a key mismatch, the user gets a copy-pasteable
recovery command.

## Previous behavior

Neither `-oStrictHostKeyChecking` nor `-oUserKnownHostsFile` was set on the egress command;
host-key policy was whatever ssh inherited.

## Why it was a problem

The policy was implicit and unmanaged. With agent forwarding enabled on the interactive hop,
a host whose key had silently changed (a man-in-the-middle, or a host impersonating another)
could be connected to — and the forwarded agent exposed to it — without verification, even
though sb already maintains a per-user `known_hosts` and a `self hostkey forget` command.

## What changed

- New `general.egress_strict_host_key_checking` option (default `accept-new` — trust-on-first-use
  with pinning; `yes`/`no` available), passed as `-oStrictHostKeyChecking`, with
  `-oUserKnownHostsFile` pointing at the user's managed `known_hosts`.
- The scp egress command construction is extracted into `buildEgressBaseCommand` so the
  security-relevant options live in one place; ttyrec's `buildSSHCommand` takes the same two
  inputs and keeps `-A` for onward auth.
- New `helpers.HostKeyWatcher` (an `io.Writer` tee'd onto egress stderr) detects OpenSSH's
  mismatch banner; on a mismatch the command prints `helpers.HostKeyMismatchHint`: a
  copy-pasteable `self hostkey forget` command (with the correct `[host]:port` token) gated
  behind an "only if you trust this change" warning.
- ttyrec now joins the recording goroutine before `Wait` closes the pipes, so the watcher
  reliably sees all stderr and a latent pipe-read/Wait race is closed.
- Configuration and usage docs describe the policy and the recovery workflow.

## How it's tested

New unit tests: `HostKeyWatcher` detection (including a marker split across writes and benign
output), `HostKeyMismatchHint` token formatting (port 22 vs non-standard port), and
command-builder tests asserting both egress paths carry the `known_hosts` file and policy.
`go build ./...`, `go test ./...` and `golangci-lint` pass.

## Test plan

- [ ] Inspect the constructed egress argv (covered by unit tests)
- [ ] A changed host key produces the forget hint and the connection is refused
- [ ] `accept-new` pins a first-seen host; `self hostkey forget` clears a stale pin