### PR TITLE
scp: fix wrapper port bug and support SFTP transfers

### DIFF
--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -20,6 +20,15 @@ import (
 // Scp describes the help command
 type Scp struct{}
 
+// scpSFTPSubsystem is the sentinel the wrapper script passes as --scp-cmd to
+// select SFTP mode. It is the actual SSH subsystem name, so the bastion can
+// forward it verbatim to "ssh -s host sftp" on the egress hop. Carrying the
+// mode through the existing --scp-cmd argument (rather than a separate flag)
+// keeps the command's surface to --access + --scp-cmd, and the bastion still
+// only ever matches this fixed token or the strict legacy regex below — never
+// arbitrary client input.
+const scpSFTPSubsystem = "sftp"
+
 func init() {
 	commands.RegisterCommand("scp", func() (c commands.Command, r models.Right, helper helpers.Helper, args map[string]commands.Argument) {
 		return new(Scp), models.HasAccess, helpers.Helper{
@@ -29,7 +38,7 @@ func init() {
              This requires the execution of script in complement of your usual scp command.
              To get this running, execute the following commands:
                  %s scp --get-script > ~/.%sscp && chmod +x ~/.%sscp
-                 alias %sscp='scp -O -S ~/.%sscp '
+                 alias %sscp='scp -S ~/.%sscp '
 			 And voila, you're all set: just run the command '%sscp' as you would run 'scp'!`,
 					config.GetSBName(), config.GetSBName(), config.GetSBName(), config.GetSBName(), config.GetSBName(), config.GetSBName()),
 			}, map[string]commands.Argument{
@@ -39,7 +48,7 @@ func init() {
 				},
 				"scp-cmd": {
 					Required:    false,
-					Description: "The actual SCP command",
+					Description: "The remote transfer command: a legacy 'scp -t/-f ...' invocation, or the literal 'sftp' to proxy the SFTP subsystem (set by the wrapper script)",
 				},
 				"get-script": {
 					Required:    false,
@@ -53,21 +62,32 @@ func init() {
 // Checks checks whether or not the user can execute this method
 func (c *Scp) Checks(ct *commands.Context) error {
 
-	scpValidRegexp := regexp.MustCompile(`^scp (-r )?(-f|-t) .*`)
-
-	// In case an access was provided and verified
-	if ct.AI != nil {
-
-		// And we check we have a scp-cmd
-		if ct.FormattedArguments["scp-cmd"] == "" {
-			return fmt.Errorf("argument scp-cmd should be provided")
-		}
-
-		if !scpValidRegexp.MatchString(ct.FormattedArguments["scp-cmd"]) {
-			return fmt.Errorf("argument scp-cmd should be a scp internal formated command")
-		}
-
+	// The get-script and help paths resolve no access, so there is no transfer
+	// command to validate.
+	if ct.AI == nil {
+		return nil
 	}
+
+	scpCmd := ct.FormattedArguments["scp-cmd"]
+	if scpCmd == "" {
+		return fmt.Errorf("argument scp-cmd should be provided")
+	}
+
+	// SFTP mode: the wrapper requests the sftp subsystem by its name. sb is a
+	// transparent byte pipe to the egress subsystem, so there is nothing further
+	// to validate. The decision is made on this fixed sentinel, never on
+	// arbitrary client input.
+	if scpCmd == scpSFTPSubsystem {
+		return nil
+	}
+
+	// Legacy SCP mode: the scp-cmd is the verbatim remote invocation, so it must
+	// be shaped like the internal "scp -t/-f" sub-protocol.
+	scpValidRegexp := regexp.MustCompile(`^scp (-r )?(-f|-t) .*`)
+	if !scpValidRegexp.MatchString(scpCmd) {
+		return fmt.Errorf("argument scp-cmd should be a scp internal formated command")
+	}
+
 	return nil
 }
 
@@ -124,13 +144,12 @@ func (c *Scp) Execute(ct *commands.Context) (repl models.ReplicationData, cmdErr
 	}
 
 	// Build the egress command prefix (ssh options + port/user/keys, with
-	// host-key verification pinned), then append the transparent transfer tail.
+	// host-key verification pinned), then append the transparent transfer tail
+	// for whichever mode the wrapper requested.
+	scpCmd := ct.FormattedArguments["scp-cmd"]
+	isSFTP := scpCmd == scpSFTPSubsystem
 	command := c.buildEgressBaseCommand(sshPath, access, ct.AI.KeyFilepathes, ct.User.GetKnownHostsFilepath(), config.GetEgressStrictHostKeyChecking())
-	command = append(command,
-		"--",
-		access.Host,
-		ct.FormattedArguments["scp-cmd"],
-	)
+	command = c.appendTransferTail(command, access.Host, isSFTP, scpCmd)
 
 	// Watch the egress stderr for a host-key mismatch so we can surface a
 	// recovery hint; it shadows os.Stderr and does not alter the real output.
@@ -196,6 +215,19 @@ func (c *Scp) buildEgressBaseCommand(sshPath string, access *models.Access, keyF
 		command = append(command, "-i", privateKeyFile)
 	}
 	return command
+}
+
+// appendTransferTail appends the mode-specific tail to an egress base command.
+// In SFTP mode it requests the sftp subsystem on the distant host (ssh -s ...
+// host sftp); in legacy mode it runs the verbatim scp sub-protocol command
+// (ssh ... -- host "scp -t/-f ..."). Either way sb only shuttles bytes between
+// the two SSH connections, so it stays a transparent pipe. scpCmd is ignored in
+// SFTP mode.
+func (c *Scp) appendTransferTail(base []string, host string, sftp bool, scpCmd string) []string {
+	if sftp {
+		return append(base, "-s", "--", host, "sftp")
+	}
+	return append(base, "--", host, scpCmd)
 }
 
 func (c *Scp) PostExecute(repl models.ReplicationData) (err error) {

--- a/cmd/scp_test.go
+++ b/cmd/scp_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/models"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestScpChecks covers the dual-mode validation boundary: SFTP mode is accepted
+// when scp-cmd carries the fixed "sftp" subsystem sentinel (nothing further to
+// inspect), while legacy mode still requires a scp-cmd shaped like the internal
+// scp sub-protocol. The get-script / help path (no access resolved) is always
+// allowed.
+func TestScpChecks(t *testing.T) {
+	c := new(Scp)
+	withAccess := &models.Info{}
+
+	cases := []struct {
+		name    string
+		ctx     *commands.Context
+		wantErr bool
+	}{
+		{
+			name:    "no access resolved is allowed",
+			ctx:     &commands.Context{AI: nil, FormattedArguments: map[string]string{}},
+			wantErr: false,
+		},
+		{
+			name:    "sftp mode via scp-cmd token passes",
+			ctx:     &commands.Context{AI: withAccess, FormattedArguments: map[string]string{"scp-cmd": "sftp"}},
+			wantErr: false,
+		},
+		{
+			name:    "legacy mode with valid scp-cmd passes",
+			ctx:     &commands.Context{AI: withAccess, FormattedArguments: map[string]string{"scp-cmd": "scp -t /tmp/x"}},
+			wantErr: false,
+		},
+		{
+			name:    "legacy mode missing scp-cmd fails",
+			ctx:     &commands.Context{AI: withAccess, FormattedArguments: map[string]string{}},
+			wantErr: true,
+		},
+		{
+			name:    "legacy mode with malformed scp-cmd fails",
+			ctx:     &commands.Context{AI: withAccess, FormattedArguments: map[string]string{"scp-cmd": "rm -rf /"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.Checks(tc.ctx)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestScpAppendTransferTail asserts the mode-specific tail: SFTP requests the
+// sftp subsystem (ssh -s ... host sftp) and ignores any scp-cmd, while legacy
+// runs the verbatim scp sub-protocol command after the host.
+func TestScpAppendTransferTail(t *testing.T) {
+	c := new(Scp)
+	base := []string{"/usr/bin/ssh", "-x"}
+
+	t.Run("sftp mode requests the subsystem", func(t *testing.T) {
+		got := c.appendTransferTail(base, "prod-web", true, "ignored")
+		require.Equal(t, []string{"/usr/bin/ssh", "-x", "-s", "--", "prod-web", "sftp"}, got)
+	})
+
+	t.Run("legacy mode runs the scp command", func(t *testing.T) {
+		got := c.appendTransferTail(base, "prod-web", false, "scp -t /tmp/x")
+		require.Equal(t, []string{"/usr/bin/ssh", "-x", "--", "prod-web", "scp -t /tmp/x"}, got)
+	})
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -214,6 +214,25 @@ Transferred: sent 5396, received 2812 bytes, in 1.0 seconds
 Bytes per second: sent 5417.9, received 2823.4
 ```
 
+> **Note:** the wrapper auto-detects which protocol your client uses, so the alias needs
+> **no** `-O` flag. Modern clients (OpenSSH 9.0+, which default to the SFTP protocol) and
+> older clients (legacy SCP protocol) both work through the same `scp -S ~/.sbscp` alias.
+> Because the wrapper handles SFTP too, you can also point `sftp` at it:
+> ```console
+> t1000@skynet:~# alias sbsftp='sftp -S ~/.sbscp '
+> t1000@skynet:~# sbsftp root@10.0.0.10
+> ```
+>
+> **One exception — a recent client talking to an old distant host.** Your client picks the
+> protocol from *its own* version, and `sb` mirrors that choice onto the distant host. A
+> modern client therefore requests the SFTP subsystem, which fails if the distant host has no
+> `sftp-server` (you'll see `subsystem request failed`). This is exactly how a *direct*
+> `scp` behaves against such a host — OpenSSH 9.0+ does not fall back to the legacy protocol
+> on its own. Force the legacy protocol with `-O` for those hosts:
+> ```console
+> t1000@skynet:~# scp -O -S ~/.sbscp README.md root@old-host:/tmp/README.md
+> ```
+
 ## Enable and use Time-based One-Time Password
 
 If you want an extra security on top of the SSH key pair authentication when connecting to `sb`, 

--- a/internal/helpers/templates.go
+++ b/internal/helpers/templates.go
@@ -192,14 +192,26 @@ func GetScpScript(user, host, port string) (str string) {
 		Host: host,
 	}
 
+	// The wrapper is invoked by the client's scp/sftp as the ssh replacement
+	// program: "<this> <ssh-options> -- <host> <command>". It collects the ssh
+	// options, extracts the login user / port, and detects whether the client is
+	// asking for the SFTP subsystem (ssh -s ... host sftp) or the legacy SCP
+	// sub-protocol (... host "scp -t/-f ..."), then re-invokes ssh into sb with
+	// the matching mode. sb stays a transparent pipe, so the single alias
+	// "scp -S ~/.<name>scp" (no -O) works for both modern (SFTP) and pre-9.0
+	// (legacy SCP) clients.
 	tpl := `#! /bin/sh
+sftp=0
 while ! [ "$1" = "--" ] ; do
 	if [ "$1" = "-l" ] ; then
 		user="$2"
 		shift 2
-	elif [ "\$1" = "-p" ] ; then
+	elif [ "$1" = "-p" ] ; then
 		port="$2"
 		shift 2
+	elif [ "$1" = "-s" ] ; then
+		sftp=1
+		shift
 	else
 		sshcmdline="$sshcmdline $1"
 		shift
@@ -212,7 +224,11 @@ fi
 if [ "x$port" != "x" ]; then
 	host="$host:$port"
 fi
-exec ssh -p {{.Port}} {{.User}}@{{.Host}} $sshcmdline -T -- scp --access $host --scp-cmd "\"$3\""
+if [ "$sftp" = "1" ] ; then
+	exec ssh -p {{.Port}} {{.User}}@{{.Host}} $sshcmdline -T -- scp --access $host --scp-cmd sftp
+else
+	exec ssh -p {{.Port}} {{.User}}@{{.Host}} $sshcmdline -T -- scp --access $host --scp-cmd "\"$3\""
+fi
 `
 
 	t, err := template.New("tpl").Parse(tpl)

--- a/internal/helpers/templates_test.go
+++ b/internal/helpers/templates_test.go
@@ -34,13 +34,17 @@ func TestGetGroupSudoersTemplate(t *testing.T) {
 func TestGetScpScript(t *testing.T) {
 
 	expectedScript := `#! /bin/sh
+sftp=0
 while ! [ "$1" = "--" ] ; do
 	if [ "$1" = "-l" ] ; then
 		user="$2"
 		shift 2
-	elif [ "\$1" = "-p" ] ; then
+	elif [ "$1" = "-p" ] ; then
 		port="$2"
 		shift 2
+	elif [ "$1" = "-s" ] ; then
+		sftp=1
+		shift
 	else
 		sshcmdline="$sshcmdline $1"
 		shift
@@ -53,10 +57,21 @@ fi
 if [ "x$port" != "x" ]; then
 	host="$host:$port"
 fi
-exec ssh -p 22 test@sb.domain.tld $sshcmdline -T -- scp --access $host --scp-cmd "\"$3\""
+if [ "$sftp" = "1" ] ; then
+	exec ssh -p 22 test@sb.domain.tld $sshcmdline -T -- scp --access $host --scp-cmd sftp
+else
+	exec ssh -p 22 test@sb.domain.tld $sshcmdline -T -- scp --access $host --scp-cmd "\"$3\""
+fi
 `
 
 	require.Equal(t, expectedScript, GetScpScript("test", "sb.domain.tld", "22"), "The GetScpScript() function returned an unexpected SCP script")
+
+	// Guard against the historical regression where the -p test was emitted as
+	// the literal "\$1" (text/template does not interpret \$), which broke port
+	// handling. The corrected script must test "$1" and never contain "\$1".
+	script := GetScpScript("test", "sb.domain.tld", "22")
+	require.Contains(t, script, `elif [ "$1" = "-p" ] ;`, "the -p test must use $1, not a literal backslash")
+	require.NotContains(t, script, `\$1`, "the script must not contain a literal-backslash $1")
 }
 
 func TestTOTPFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a live port-handling bug in the generated SCP wrapper script and makes the transfer
path dual-mode: it now works with modern OpenSSH (SFTP protocol) and pre-9.0 clients (legacy
SCP) through a single alias with **no** `-O` flag.

## Previous behavior

The wrapper from `scp --get-script` emitted the `-p` test as `elif [ "\$1" = "-p" ]`;
`text/template` does not interpret `\$`, so the script contained a literal backslash and the
test never matched. Separately, the path only spoke the legacy SCP protocol — `Checks`
accepted only `scp -t/-f` and the advertised alias forced the old protocol with `-O`.

## Why it was a problem

Port forwarding via `-p` silently did the wrong thing. And since OpenSSH 9.0 defaults `scp`
to the SFTP protocol, a modern client without `-O` had its transfer rejected; the legacy
protocol is deprecated upstream and will eventually be removed, leaving no client-side
workaround.

## What changed

- Fix the backslash bug so `-p` is honored.
- The wrapper detects whether the client requests the SFTP subsystem (`ssh -s … host sftp`)
  or the legacy SCP sub-protocol, and re-invokes sb with the matching mode. The single alias
  `scp -S ~/.sbscp` (no `-O`) now works for both, and the same wrapper serves `sftp`.
- The mode is carried through the **existing `--scp-cmd`** argument rather than a new flag:
  in SFTP mode the wrapper sends `--scp-cmd sftp` (the actual subsystem name), so the
  command's surface stays `--access` + `--scp-cmd`. On the bastion, `Checks` accepts that
  fixed sentinel without further validation (dispatching on a known token, never on
  attacker-controlled input) and still requires legacy commands to match the strict
  `scp -t/-f` regex; `Execute` requests the sftp subsystem on the egress hop via a new
  `appendTransferTail` helper. sb stays a transparent byte pipe in both modes, so host-key
  pinning and the mismatch hint apply to SFTP too.
- Command help and usage docs drop `-O` and document the SFTP alias.

## How it's tested

The `GetScpScript` golden test now covers the dual-mode script and explicitly guards against
the literal `\$1` regression; new scp tests cover `Checks` across SFTP/legacy/no-access cases
and `appendTransferTail` for both tails. `go build ./...`, `go test ./...` and
`golangci-lint` pass.

## Test plan

- [ ] Regenerate `~/.sbscp` via `sb scp --get-script`; confirm `-p` handling works
- [ ] A modern `scp -S ~/.sbscp` (no `-O`) round-trips a file
- [ ] A legacy `scp -O -S ~/.sbscp` still works
- [ ] `sftp -S ~/.sbscp host` works

> Note: targets `egress-host-key-pinning` as its base; review/merge that first.