### PR TITLE
helpers: stop a malformed mosh command line from panicking the parser

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -20,111 +20,6 @@ type Helper struct {
 }
 
 // ParseArguments parses the os.Args arguments
-func ParseArgumentsNew(clArgs []string) (c string, ca []string, rest []string, err error) {
-
-	// We initialize our client with "ssh"
-	c = "ssh"
-
-	// Absolutely no arguments were provided (that's odd, we should at least have ourselves at $0)
-	if len(clArgs) == 0 {
-		return
-	}
-
-	// We start by dropping the script name
-	clArgs = clArgs[1:]
-
-	// Absolutely no arguments were provided
-	if len(clArgs) == 0 {
-		return
-	}
-
-	// We might have been called from two ways:
-	// - directly, then arguments are: ["command", "--arg1", "val1, "--arg2", ...]
-	// - through SSH client, then arguments are: ["-c", "command --arg1 val1 --arg2 ..."]
-	if clArgs[0] != "-c" {
-		// Nothing to do
-	} else {
-		if len(clArgs) == 1 {
-			// No arguments were provided
-			return
-		}
-		// We drop the "-c" and convert the arguments string to an array of arguments
-		clArgs, err = ParseCommandLine(clArgs[1])
-		if err != nil {
-			return
-		}
-	}
-
-	// We now have two different cases:
-	// - just a basic slice of arguments (in case of direct call and SSH)
-	// - something starting with ["mosh-server", "new", ..., "--", args...]
-	if clArgs[0] == "mosh-server" {
-		c = "mosh"
-
-		// We drop the non-arguments part of the mosh command line.
-		// Second argument should be "new", in case it is not, we check this case
-		if clArgs[1] == "new" {
-			clArgs = clArgs[2:]
-		} else {
-			clArgs = clArgs[1:]
-		}
-
-		// Mosh wraps around every argument with ' and escapes the ', we'll try and fix that
-		for i := 0; i < len(clArgs); i++ {
-			clArgs[i] = strings.TrimPrefix(strings.TrimSuffix(strings.ReplaceAll(clArgs[i], `\'`, "'"), "'"), "'")
-		}
-
-		// Let's build a flag parser for mosh options!
-		moshFlagSet := flag.NewFlagSet("mosh", flag.ContinueOnError)
-
-		// The flag package displays a nice message if an undeclared flag is found... but that's not what we want!
-		// Let's redirect output to an abandoned buffer
-		var buf bytes.Buffer
-		moshFlagSet.SetOutput(&buf)
-
-		// This flags are extracted from mosh-server man page
-		iface := moshFlagSet.Bool("s", false, "bind to the local interface used for an incoming SSH connection, given in the SSH_CONNECTION environment variable (for multihomed hosts)")
-		v := moshFlagSet.Bool("v", false, "Print some debugging information even after detaching.  More instances of this flag will result in more debugging information.")
-		ip := moshFlagSet.String("i", "", "IP address of the local interface to bind (for multihomed hosts)")
-		colors := moshFlagSet.String("c", "8", "Number of colors to advertise to applications through TERM (e.g. 8, 256)")
-		lang := moshFlagSet.String("l", "", "Locale-related environment variable to try as part of a fallback environment, if the startup environment does not specify a character set of UTF-8.")
-		moshFlagSet.String("p", "", "UDP port number or port-range to bind.  -p 0 will let the operating system pick an available UDP port.")
-
-		// Let's parse our mosh-server arguments. We intentionally ignore the parse
-		// error and proceed best-effort: undeclared mosh flags are expected here and
-		// must not abort parsing (the remaining args are recovered via Args below).
-		_ = moshFlagSet.Parse(clArgs)
-
-		// And keep everything that was trailing for the next step
-		clArgs = moshFlagSet.Args()
-
-		// We push everything we parsed into our clientArguments slice
-		// Everything except the ports to use, as they're coded in our configuration file
-		ca = make([]string, 0)
-		if *iface {
-			ca = append(ca, "-s")
-		}
-		if *v {
-			ca = append(ca, "-v")
-		}
-		if *ip != "" {
-			ca = append(ca, "-i", *ip)
-		}
-		if *colors != "" {
-			ca = append(ca, "-c", *colors)
-		}
-		if *lang != "" {
-			ca = append(ca, "-l", *lang)
-		}
-	}
-
-	// We return all remaining arguments, that's what the user really wanted to give us
-	rest = clArgs
-
-	return
-}
-
-// ParseArguments parses the os.Args arguments
 func ParseArguments(clArgs []string) (c string, ca []string, ba map[string]bool, rest []string, err error) {
 
 	// We initialize our client with "ssh"
@@ -165,6 +60,17 @@ func ParseArguments(clArgs []string) (c string, ca []string, ba map[string]bool,
 	// - something starting with ["mosh-server", "new", ..., "--", args...]
 	if clArgs[0] == "mosh-server" {
 		c = "mosh"
+
+		// A mosh invocation must carry at least one token after "mosh-server"
+		// (normally the "new" subsystem and its arguments). A bare "mosh-server"
+		// is malformed: fail closed with a clear error instead of indexing
+		// clArgs[1] past the end of the slice. This input arrives from the
+		// SSH-forced command before any authorization, so a panic here was a
+		// denial-of-service reachable by any caller.
+		if len(clArgs) < 2 {
+			err = fmt.Errorf("malformed mosh-server command line: missing arguments after \"mosh-server\"")
+			return
+		}
 
 		// We drop the non-arguments part of the mosh command line.
 		// Second argument should be "new", in case it is not, we check this case
@@ -266,6 +172,15 @@ func ParseArguments(clArgs []string) (c string, ca []string, ba map[string]bool,
 }
 
 func RegroupCommandArguments(clArgs []string) (args []string) {
+
+	// Nothing to regroup for an empty argument list, and indexing clArgs[0]
+	// below would panic. This is reachable from ParseArguments when a mosh
+	// command line consumes every token (e.g. "mosh-server new" with no trailing
+	// command), so guard it rather than relying on every caller passing a
+	// non-empty slice.
+	if len(clArgs) == 0 {
+		return clArgs
+	}
 
 	var j int
 	firstArg := clArgs[0]

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -124,6 +124,51 @@ func TestParseArgumentsMosh(t *testing.T) {
 
 }
 
+// TestParseArgumentsMoshMalformed guards the degenerate mosh command lines that
+// previously panicked with an index-out-of-range. This input comes from the
+// SSH-forced command and is parsed before any authorization, so a panic here
+// was a denial of service reachable by any caller. A bare "mosh-server" must
+// now return a clean error, and "mosh-server new" (which consumes every token,
+// leaving an empty slice for RegroupCommandArguments) must parse without
+// panicking.
+func TestParseArgumentsMoshMalformed(t *testing.T) {
+
+	tests := []testParseArguments{
+		{
+			i: []string{"sb", "-c", "mosh-server"},
+			o: testParseArgumentsOutputData{
+				err: fmt.Errorf("malformed mosh-server command line: missing arguments after \"mosh-server\""),
+			},
+		},
+		{
+			// "new" is consumed, leaving no further tokens; this must not panic
+			// in RegroupCommandArguments and yields the mosh client with no
+			// remaining command.
+			i: []string{"sb", "-c", "mosh-server new"},
+			o: testParseArgumentsOutputData{
+				client:          "mosh",
+				clientArguments: []string{"-c", "8"},
+				arguments:       []string{}, // empty, but crucially not a panic
+			},
+		},
+	}
+
+	for i, test := range tests {
+		c, ca, ba, a, err := ParseArguments(test.i)
+		if test.o.err == nil {
+			require.NoError(t, err, fmt.Sprintf("There was an unexpected error parsing arguments on test %d", i+1))
+		} else {
+			require.EqualError(t, err, test.o.err.Error(), fmt.Sprintf("An error should have been returned on test %d", i+1))
+			continue
+		}
+
+		require.Equal(t, test.o.client, c, fmt.Sprintf("The client has been badly computed on test %d", i+1))
+		require.Equal(t, test.o.clientArguments, ca, fmt.Sprintf("The client arguments were badly computed on test %d", i+1))
+		require.Equal(t, test.o.sbArguments, ba, fmt.Sprintf("The sb arguments were badly computed on test %d", i+1))
+		require.Equal(t, test.o.arguments, a, fmt.Sprintf("The remaining arguments were badly computed on test %d", i+1))
+	}
+}
+
 func TestParseArgumentsSBArguments(t *testing.T) {
 
 	tests := []testParseArguments{


### PR DESCRIPTION
## Summary

Fixes two index-out-of-range panics on the argument-parsing path that
runs on the SSH-forced command line **before any authorization**, and
removes a dead, identically-buggy duplicate of the parser.

## Previous behavior

`ParseArguments` checked `clArgs[1]` (the token after `mosh-server`)
without confirming a second element existed. A forced command of exactly
`mosh-server` (`ssh bastion mosh-server`) tokenizes to a one-element
slice, so the access panicked. Downstream, `mosh-server new` consumes
both tokens and hands an empty slice to `RegroupCommandArguments`, which
then indexed `clArgs[0]` and panicked as well.

## Why it was a problem

`ParseArguments` runs before authorization, so either panic was a
denial-of-service reachable by anyone who could reach the bastion shell.

## What changed

- The mosh branch returns a clear `malformed mosh-server command line`
  error when no token follows `mosh-server`, instead of indexing past the
  end of the slice.
- `RegroupCommandArguments` returns its input unchanged for an empty
  slice (reachable via the `mosh-server new` path).
- Deletes `ParseArgumentsNew`, a dead near-duplicate referenced nowhere.
  It was byte-for-byte identical to `ParseArguments` except that it
  omitted command-regrouping and the `-v/-i/-d` sb-flag parsing (and the
  `ba` return value) — a strictly lesser, orphaned copy that carried the
  same `clArgs[1]` bug. Removing it stops the bug resurfacing in a stale
  path.

## How it's tested

New `TestParseArgumentsMoshMalformed`: a bare `mosh-server` returns the
error, and `mosh-server new` parses to the mosh client with no remaining
command instead of panicking. Existing argument-parsing tests still pass;
`go build ./...`, `go test ./...` and `golangci-lint` are clean.

## Test plan

- [ ] `ssh bastion mosh-server` no longer crashes sb; it reports a parse error
- [ ] A normal `mosh-server new -- <cmd>` invocation still works
- [ ] Regular ssh command parsing is unaffected
