### PR TITLE
config: register defaults unconditionally, not only when no config file exists

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,48 +29,72 @@ func init() {
 	viper.AddConfigPath(".")
 	viper.AddConfigPath("/etc/sb")
 
-	err := viper.ReadInConfig()
-	if err != nil {
+	// Register the built-in defaults unconditionally, BEFORE reading the config
+	// file. viper applies defaults at its lowest precedence, so a value present
+	// in the config file still overrides the corresponding default — but the
+	// defaults must be registered regardless of whether a config file exists.
+	//
+	// Previously these SetDefault calls lived inside the ConfigFileNotFoundError
+	// branch below, so they only ran when NO config file was found. In the normal
+	// production case — a config file is present but omits some keys — none of the
+	// defaults were registered, and every omitted key silently resolved to its
+	// zero value instead of the intended default. For example commands.ssh_command
+	// became "" instead of "ttyrec", which main.go relies on to dispatch a host
+	// connection. Registering them up front fixes that whole class of bug.
+	setDefaults(viper.GetViper())
 
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-
-			// General instance configuration
-			viper.SetDefault("general.name", "sb")
-			viper.SetDefault("general.location", "earth")
-			viper.SetDefault("general.hostname", "sb.domain.tld")
-			viper.SetDefault("general.binary_path", "/opt/sb/sb")
-			viper.SetDefault("general.ssh_port", "22")
-			viper.SetDefault("general.mosh_ports_range", "40000:49999")
-			viper.SetDefault("general.env_vars_to_forward", []string{"USER"})
-			viper.SetDefault("general.sb_user", "sb")
-			viper.SetDefault("general.sb_user_home", "/home/sb")
-			viper.SetDefault("general.encryption-key", DefaultEncryptionKey)
-			viper.SetDefault("general.egress_strict_host_key_checking", defaultEgressStrictHostKeyChecking)
-
-			// Commands configuration
-			viper.SetDefault("commands.ssh_command", "ttyrec")
-
-			// Replication configuration
-			viper.SetDefault("replication.enabled", false)
-			viper.SetDefault("replication.queue.type", "")
-			viper.SetDefault("replication.queue.googlepubsub.project", "")
-			viper.SetDefault("replication.queue.googlepubsub.topic", "")
-
-			// TTYrecs offloading configuration
-			viper.SetDefault("ttyrecsoffloading.enabled", false)
-			viper.SetDefault("ttyrecsoffloading.storage.type", "")
-			viper.SetDefault("ttyrecsoffloading.storage.gcs.bucket", "")
-			viper.SetDefault("ttyrecsoffloading.storage.gcs.objects-base-path", "")
-			viper.SetDefault("ttyrecsoffloading.storage.gcs.endpoint-url", "")
-			viper.SetDefault("ttyrecsoffloading.storage.s3.bucket", "")
-			viper.SetDefault("ttyrecsoffloading.storage.s3.keys-base-path", "")
-
-		} else {
-
-			os.Exit(-1)
-
+	if err := viper.ReadInConfig(); err != nil {
+		// A missing config file is expected and harmless: the defaults registered
+		// above keep sb working. Any other error means a config file exists but
+		// could not be read or parsed (e.g. malformed YAML); fail loudly with a
+		// diagnostic instead of the previous silent os.Exit(-1), which gave the
+		// operator no clue why sb refused to start.
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			fmt.Fprintf(os.Stderr, "unable to read sb configuration: %s\n", err)
+			os.Exit(1)
 		}
 	}
+}
+
+// setDefaults registers every built-in configuration default on v. It is called
+// unconditionally at startup so that the defaults apply whether or not a config
+// file is present and regardless of which keys that file sets; values from the
+// config file override these because viper ranks defaults at the lowest
+// precedence. It takes the viper instance explicitly (rather than using the
+// package-level functions) so it can be exercised hermetically in tests against
+// a fresh viper.New() without disturbing the process-wide instance.
+func setDefaults(v *viper.Viper) {
+
+	// General instance configuration
+	v.SetDefault("general.name", "sb")
+	v.SetDefault("general.location", "earth")
+	v.SetDefault("general.hostname", "sb.domain.tld")
+	v.SetDefault("general.binary_path", "/opt/sb/sb")
+	v.SetDefault("general.ssh_port", "22")
+	v.SetDefault("general.mosh_ports_range", "40000:49999")
+	v.SetDefault("general.env_vars_to_forward", []string{"USER"})
+	v.SetDefault("general.sb_user", "sb")
+	v.SetDefault("general.sb_user_home", "/home/sb")
+	v.SetDefault("general.encryption-key", DefaultEncryptionKey)
+	v.SetDefault("general.egress_strict_host_key_checking", defaultEgressStrictHostKeyChecking)
+
+	// Commands configuration
+	v.SetDefault("commands.ssh_command", "ttyrec")
+
+	// Replication configuration
+	v.SetDefault("replication.enabled", false)
+	v.SetDefault("replication.queue.type", "")
+	v.SetDefault("replication.queue.googlepubsub.project", "")
+	v.SetDefault("replication.queue.googlepubsub.topic", "")
+
+	// TTYrecs offloading configuration
+	v.SetDefault("ttyrecsoffloading.enabled", false)
+	v.SetDefault("ttyrecsoffloading.storage.type", "")
+	v.SetDefault("ttyrecsoffloading.storage.gcs.bucket", "")
+	v.SetDefault("ttyrecsoffloading.storage.gcs.objects-base-path", "")
+	v.SetDefault("ttyrecsoffloading.storage.gcs.endpoint-url", "")
+	v.SetDefault("ttyrecsoffloading.storage.s3.bucket", "")
+	v.SetDefault("ttyrecsoffloading.storage.s3.keys-base-path", "")
 }
 
 // GetSBName returns sb's name (AKA the alias to set in user's path)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -138,4 +139,34 @@ func TestGetEgressStrictHostKeyChecking(t *testing.T) {
 		require.Equal(t, defaultEgressStrictHostKeyChecking, GetEgressStrictHostKeyChecking())
 		require.NotEmpty(t, GetEgressStrictHostKeyChecking())
 	})
+}
+
+// TestSetDefaultsAppliedAlongsidePartialConfig is the regression test for the
+// bug this change fixes: defaults must apply even when a config file is present
+// but only sets some keys. It drives a fresh viper instance (so it never touches
+// the process-wide one) exactly as init() does — register the defaults, then
+// read a config — and asserts that a key set in the file wins while an omitted
+// key still resolves to its default. Before the fix the defaults were only
+// registered when no config file existed, so the omitted key would have
+// resolved to "".
+func TestSetDefaultsAppliedAlongsidePartialConfig(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+
+	setDefaults(v)
+
+	// A config file that sets only general.name and leaves everything else out.
+	partialConfig := []byte("general:\n  name: custom-bastion\n")
+	require.NoError(t, v.ReadConfig(bytes.NewReader(partialConfig)))
+
+	// The key present in the file overrides its default...
+	require.Equal(t, "custom-bastion", v.GetString("general.name"))
+
+	// ...while keys omitted from the file still resolve to their defaults rather
+	// than the empty string. commands.ssh_command in particular must stay
+	// "ttyrec": main.go uses it to dispatch host connections.
+	require.Equal(t, "ttyrec", v.GetString("commands.ssh_command"))
+	require.Equal(t, "/opt/sb/sb", v.GetString("general.binary_path"))
+	require.Equal(t, "22", v.GetString("general.ssh_port"))
+	require.Equal(t, "sb", v.GetString("general.sb_user"))
 }


### PR DESCRIPTION
## Summary

Registers the built-in configuration defaults unconditionally, so they
apply whether or not a config file is present and regardless of which
keys that file sets. Also replaces a silent `os.Exit(-1)` on a malformed
config with a diagnostic.

## Previous behavior

Every `viper.SetDefault` call lived inside the `ConfigFileNotFoundError`
branch of `init()`, so the defaults were registered only when **no**
`sb.yml`/`sb.yaml` was found at all. A non-`ConfigFileNotFoundError` read
error did a bare `os.Exit(-1)` with no message.

## Why it was a problem

In the normal production case — a config file is present but omits some
keys — none of the defaults were registered, so each omitted key silently
resolved to its zero value. `commands.ssh_command` became `""` instead of
`"ttyrec"` (main.go depends on it to dispatch host connections);
`general.binary_path`, `general.ssh_port` and others were equally
affected. A partial-but-valid config could break sb in confusing ways,
and a malformed config killed the process with no diagnostic.

## What changed

- Extracted the defaults into `setDefaults(*viper.Viper)` and call it
  unconditionally before `ReadInConfig`. viper ranks defaults lowest, so
  a value in the config file still overrides its default; the difference
  is that omitted keys now fall back to their default in all cases.
- `ReadInConfig` error handling now ignores only
  `ConfigFileNotFoundError` and, for any other error (e.g. malformed
  YAML), prints to stderr before exiting non-zero.
- `setDefaults` takes the viper instance explicitly so it is testable
  against a fresh `viper.New()` without touching the global instance.

## How it's tested

New `TestSetDefaultsAppliedAlongsidePartialConfig` drives a fresh viper as
`init()` does: registers the defaults, reads a config that sets only
`general.name`, and asserts the set key wins while omitted keys
(`commands.ssh_command`, `binary_path`, `ssh_port`, `sb_user`) still
resolve to their defaults rather than `""`. Existing `TestInitialize`
still passes; `go build ./...`, `go test ./...` and `golangci-lint` are
clean.

## Test plan

- [ ] A config file that omits `commands.ssh_command` still dispatches host connections (resolves to `ttyrec`)
- [ ] A config file value still overrides the matching default
- [ ] A malformed YAML config now prints an error instead of exiting silently
