### PR TITLE
commands: extract authorization into a unit-tested gate

### DIFF
--- a/internal/commands/authorize.go
+++ b/internal/commands/authorize.go
@@ -1,0 +1,227 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/golgeek/sb/internal/models"
+)
+
+// accessBuilderFunc resolves a user-supplied access string ("user@host[:port]"
+// or a bare alias) into a models.Access. The production implementation is
+// models.BuildSBAccessFromUserInput, which performs a DNS resolution of the
+// host as part of the build; tests inject a hermetic replacement.
+type accessBuilderFunc func(input string) (*models.Access, error)
+
+// accessCheckerFunc reports whether the given user is granted the candidate
+// access, returning the matching grants on success. The production
+// implementation is (*models.User).HasAccess, which reads the per-user and
+// per-group accesses databases; tests inject a hermetic replacement.
+type accessCheckerFunc func(user *models.User, ba *models.Access) (*models.Info, error)
+
+// authorizer is the authorization gate of the command dispatcher: it decides
+// whether a user may run a command registered at a given rights level. It is
+// deliberately a small struct holding only the two effectful dependencies of
+// the HasAccess level (DNS resolution and accesses-database lookups), injected
+// through newAuthorizer so the security-critical decision logic can be unit
+// tested hermetically.
+type authorizer struct {
+	buildAccess accessBuilderFunc
+	hasAccess   accessCheckerFunc
+}
+
+// authorizerOption customizes an authorizer built by newAuthorizer.
+type authorizerOption func(*authorizer)
+
+// withAccessBuilder overrides how the "access" argument is resolved into a
+// models.Access. Intended for tests, which must not perform DNS lookups.
+func withAccessBuilder(f accessBuilderFunc) authorizerOption {
+	return func(a *authorizer) {
+		a.buildAccess = f
+	}
+}
+
+// withAccessChecker overrides how a user's grant for an access is looked up.
+// Intended for tests, which must not touch the accesses databases.
+func withAccessChecker(f accessCheckerFunc) authorizerOption {
+	return func(a *authorizer) {
+		a.hasAccess = f
+	}
+}
+
+// newAuthorizer returns an authorizer wired with the production dependencies
+// (DNS-resolving access builder, database-backed access lookup), then applies
+// the given options. Call sites on the dispatch path use newAuthorizer() as-is;
+// tests pass options to substitute hermetic fakes.
+func newAuthorizer(opts ...authorizerOption) *authorizer {
+	a := &authorizer{
+		buildAccess: models.BuildSBAccessFromUserInput,
+		hasAccess: func(user *models.User, ba *models.Access) (*models.Info, error) {
+			return user.HasAccess(ba)
+		},
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// authorize enforces a command's rights level for a user and is the single
+// authorization gate of the dispatcher: every command execution must pass
+// through it exactly once, before the command's own Checks/Execute run.
+//
+// Parameters:
+//   - user: the authorization subject (the calling sb account). It is the
+//     same object as ct.User on the dispatch path; it is passed explicitly so
+//     the subject of the decision is visible at the call site.
+//   - rights: the rights level the command was registered with.
+//   - ct: the command context. authorize reads ct.FormattedArguments["access"]
+//     and ct.Group, writes the audit trail through ct.Log, and on a successful
+//     HasAccess check populates ct.AI (matching grants) and ct.BA (resolved
+//     target) for the command to consume.
+//
+// It returns nil when the user is allowed to run the command and a descriptive
+// error otherwise. Every refusal — and any internal failure on the HasAccess
+// path — leaves the audit log marked not-allowed; audit-write failures are
+// reported to stderr without changing the decision. The decision logic fails
+// closed: a rights level this function does not recognize is refused rather
+// than allowed, and a group-scoped level with no resolved group is refused
+// rather than dereferencing a nil group.
+func (a *authorizer) authorize(user *models.User, rights models.Right, ct *Context) error {
+
+	switch rights {
+
+	case models.Public:
+		// Public commands are available to every sb account.
+		return nil
+
+	case models.Private:
+		// Private commands must be run by root.
+		if user.User.Username != "root" {
+			logAuditWarn(ct.Log.SetAllowed(false))
+			return fmt.Errorf("only root user can execute this command on sb")
+		}
+		return nil
+
+	case models.HasAccess:
+		return a.authorizeAccess(user, ct)
+
+	case models.GroupMember:
+		grp, err := requireGroup(ct)
+		if err != nil {
+			return err
+		}
+		if !user.IsMemberOfGroup(grp.Name) {
+			logAuditWarn(ct.Log.SetAllowed(false))
+			return fmt.Errorf("user is not a member of the group")
+		}
+		return nil
+
+	case models.GroupACLKeeper:
+		grp, err := requireGroup(ct)
+		if err != nil {
+			return err
+		}
+		if !user.IsACLKeeperOfGroup(grp.Name) {
+			logAuditWarn(ct.Log.SetAllowed(false))
+			return fmt.Errorf("user is not an ACL keeper of the group")
+		}
+		return nil
+
+	case models.GroupGateKeeper:
+		grp, err := requireGroup(ct)
+		if err != nil {
+			return err
+		}
+		if !user.IsGateKeeperOfGroup(grp.Name) {
+			logAuditWarn(ct.Log.SetAllowed(false))
+			return fmt.Errorf("user is not a gate keeper of the group")
+		}
+		return nil
+
+	case models.GroupOwner:
+		// Owners of the special "owners" super-group administer every group,
+		// so they pass group-owner checks for any group.
+		grp, err := requireGroup(ct)
+		if err != nil {
+			return err
+		}
+		if !user.IsOwnerOfGroup(grp.Name) && !user.IsOwnerOfGroup("owners") {
+			logAuditWarn(ct.Log.SetAllowed(false))
+			return fmt.Errorf("user is not an owner of the group")
+		}
+		return nil
+
+	case models.SBOwner:
+		// sb-wide administration is reserved to owners of the "owners"
+		// super-group, or to root itself (UID 0).
+		if !user.IsOwnerOfGroup("owners") && user.User.Uid != "0" {
+			logAuditWarn(ct.Log.SetAllowed(false))
+			return fmt.Errorf("user is not a sb owner")
+		}
+		return nil
+
+	default:
+		// Fail closed: a rights level we do not recognize (e.g. a new level
+		// added to models without a matching case here) must never grant
+		// access by falling through the switch.
+		logAuditWarn(ct.Log.SetAllowed(false))
+		return fmt.Errorf("unrecognized rights level %d: refusing execution", rights)
+	}
+}
+
+// authorizeAccess enforces the HasAccess rights level: when an "access"
+// argument is present, it resolves it and checks the user's grants, recording
+// the requested target in the audit log either way.
+//
+// A missing or empty "access" argument is allowed through with ct.AI and ct.BA
+// left nil: commands at this level have modes that target no host (for example
+// scp's --get-script), and their Execute handles the nil case. When the
+// argument is present, a resolution failure, a grants-lookup failure, or an
+// unauthorized target each refuse the command and mark the audit log
+// not-allowed; on success the matching grants (ct.AI) and the resolved target
+// (ct.BA) are attached to the context for the command to consume.
+func (a *authorizer) authorizeAccess(user *models.User, ct *Context) error {
+
+	host, ok := ct.FormattedArguments["access"]
+	if !ok || host == "" {
+		return nil
+	}
+
+	ba, err := a.buildAccess(host)
+	if err != nil {
+		logAuditWarn(ct.Log.SetAllowed(false))
+		return err
+	}
+
+	// Record the requested target in the audit log before deciding, so even
+	// refused attempts keep a trace of where the user tried to go.
+	logAuditWarn(ct.Log.SetTargetAccess(ba))
+
+	ai, err := a.hasAccess(user, ba)
+	if err != nil {
+		logAuditWarn(ct.Log.SetAllowed(false))
+		return err
+	}
+	if !ai.Authorized {
+		logAuditWarn(ct.Log.SetAllowed(false))
+		return fmt.Errorf("user can't access the host %s", ba.ShortString())
+	}
+
+	ct.AI = ai
+	ct.BA = ba
+	return nil
+}
+
+// requireGroup returns the group resolved from the command's --group argument,
+// or refuses the command (marking the audit log not-allowed) when no group is
+// attached to the context. Group-scoped rights levels are meaningless without
+// a group, and reaching one without a resolved group must fail closed instead
+// of dereferencing nil — the situation is reachable if a group-scoped command
+// ever registers its "group" argument as optional.
+func requireGroup(ct *Context) (*models.Group, error) {
+	if ct.Group == nil {
+		logAuditWarn(ct.Log.SetAllowed(false))
+		return nil, fmt.Errorf("this command requires a group, but none was provided")
+	}
+	return ct.Group, nil
+}

--- a/internal/commands/authorize_test.go
+++ b/internal/commands/authorize_test.go
@@ -1,0 +1,437 @@
+package commands
+
+import (
+	"errors"
+	osuser "os/user"
+	"strings"
+	"testing"
+
+	"github.com/golgeek/sb/internal/models"
+)
+
+// testUser builds a models.User suitable for hermetic authorization tests: a
+// plain os/user identity plus an explicit group-membership map, with no system
+// lookup involved.
+func testUser(username, uid string, groups map[string]*models.Group) *models.User {
+	return &models.User{
+		User:   &osuser.User{Username: username, Uid: uid},
+		Groups: groups,
+	}
+}
+
+// group is a shorthand to declare a named group with the given role flags in a
+// user's membership map.
+func group(name string, member, aclKeeper, gateKeeper, owner bool) *models.Group {
+	return &models.Group{
+		Name:       name,
+		Member:     member,
+		ACLKeeper:  aclKeeper,
+		GateKeeper: gateKeeper,
+		Owner:      owner,
+	}
+}
+
+// testContext builds a Context for authorization tests. The embedded Log has
+// no databases attached, so the audit writes performed by authorize are
+// exercised but never touch the filesystem. Allowed is pre-set to true so a
+// test can detect that a refusal explicitly flipped it to false (the zero
+// value could not distinguish "flipped" from "never written").
+func testContext(user *models.User, grp *models.Group, args map[string]string) *Context {
+	return &Context{
+		User:               user,
+		Log:                &models.Log{Allowed: true},
+		Group:              grp,
+		FormattedArguments: args,
+	}
+}
+
+// TestAuthorize covers the full authorization matrix: every rights level, the
+// "owners" super-group escalations, the root/UID-0 special cases, the
+// fail-closed paths (group-scoped level without a group, unrecognized rights
+// level), and the audit-log side effects of refusals.
+func TestAuthorize(t *testing.T) {
+
+	// memberGroups is a membership map for a user who is a plain member of
+	// "team" (no ACL-keeper/gate-keeper/owner roles anywhere).
+	memberGroups := map[string]*models.Group{
+		"team": group("team", true, false, false, false),
+	}
+
+	team := &models.Group{Name: "team"}
+
+	tests := []struct {
+		name   string
+		rights models.Right
+		user   *models.User
+		group  *models.Group // resolved --group target, nil when absent
+		// wantErr is the exact error message expected, empty for success.
+		wantErr string
+		// wantAllowedFlipped asserts the refusal marked the audit log
+		// not-allowed (the test context pre-sets Allowed to true).
+		wantAllowedFlipped bool
+	}{
+		{
+			name:   "public allows anyone",
+			rights: models.Public,
+			user:   testUser("alice", "1000", nil),
+		},
+		{
+			name:   "private allows root",
+			rights: models.Private,
+			user:   testUser("root", "0", nil),
+		},
+		{
+			name:               "private refuses non-root",
+			rights:             models.Private,
+			user:               testUser("alice", "1000", nil),
+			wantErr:            "only root user can execute this command on sb",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:   "group member allows member",
+			rights: models.GroupMember,
+			user:   testUser("alice", "1000", memberGroups),
+			group:  team,
+		},
+		{
+			name:               "group member refuses non-member",
+			rights:             models.GroupMember,
+			user:               testUser("alice", "1000", nil),
+			group:              team,
+			wantErr:            "user is not a member of the group",
+			wantAllowedFlipped: true,
+		},
+		{
+			// Roles are independent flags (each maps to its own system
+			// group), so holding the owner role does not imply the member
+			// flag — and the member level must check exactly that flag.
+			name:   "group member refuses owner without the member flag",
+			rights: models.GroupMember,
+			user: testUser("alice", "1000", map[string]*models.Group{
+				"team": group("team", false, false, false, true),
+			}),
+			group:              team,
+			wantErr:            "user is not a member of the group",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:               "group member refuses member of another group",
+			rights:             models.GroupMember,
+			user:               testUser("alice", "1000", memberGroups),
+			group:              &models.Group{Name: "other"},
+			wantErr:            "user is not a member of the group",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:   "group ACL keeper allows ACL keeper",
+			rights: models.GroupACLKeeper,
+			user: testUser("alice", "1000", map[string]*models.Group{
+				"team": group("team", true, true, false, false),
+			}),
+			group: team,
+		},
+		{
+			name:               "group ACL keeper refuses plain member",
+			rights:             models.GroupACLKeeper,
+			user:               testUser("alice", "1000", memberGroups),
+			group:              team,
+			wantErr:            "user is not an ACL keeper of the group",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:   "group gate keeper allows gate keeper",
+			rights: models.GroupGateKeeper,
+			user: testUser("alice", "1000", map[string]*models.Group{
+				"team": group("team", true, false, true, false),
+			}),
+			group: team,
+		},
+		{
+			name:               "group gate keeper refuses plain member",
+			rights:             models.GroupGateKeeper,
+			user:               testUser("alice", "1000", memberGroups),
+			group:              team,
+			wantErr:            "user is not a gate keeper of the group",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:   "group owner allows owner of the group",
+			rights: models.GroupOwner,
+			user: testUser("alice", "1000", map[string]*models.Group{
+				"team": group("team", true, false, false, true),
+			}),
+			group: team,
+		},
+		{
+			name:   "group owner allows owner of the owners super-group",
+			rights: models.GroupOwner,
+			user: testUser("alice", "1000", map[string]*models.Group{
+				"owners": group("owners", true, false, false, true),
+			}),
+			group: team,
+		},
+		{
+			name:               "group owner refuses plain member",
+			rights:             models.GroupOwner,
+			user:               testUser("alice", "1000", memberGroups),
+			group:              team,
+			wantErr:            "user is not an owner of the group",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:   "group owner refuses mere member of the owners group",
+			rights: models.GroupOwner,
+			user: testUser("alice", "1000", map[string]*models.Group{
+				"owners": group("owners", true, false, false, false),
+			}),
+			group:              team,
+			wantErr:            "user is not an owner of the group",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:   "sb owner allows owner of the owners super-group",
+			rights: models.SBOwner,
+			user: testUser("alice", "1000", map[string]*models.Group{
+				"owners": group("owners", true, false, false, true),
+			}),
+		},
+		{
+			name:   "sb owner allows UID 0",
+			rights: models.SBOwner,
+			user:   testUser("root", "0", nil),
+		},
+		{
+			name:               "sb owner refuses regular user",
+			rights:             models.SBOwner,
+			user:               testUser("alice", "1000", memberGroups),
+			wantErr:            "user is not a sb owner",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:               "group member without resolved group fails closed",
+			rights:             models.GroupMember,
+			user:               testUser("alice", "1000", memberGroups),
+			wantErr:            "this command requires a group, but none was provided",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:               "group ACL keeper without resolved group fails closed",
+			rights:             models.GroupACLKeeper,
+			user:               testUser("alice", "1000", memberGroups),
+			wantErr:            "this command requires a group, but none was provided",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:               "group gate keeper without resolved group fails closed",
+			rights:             models.GroupGateKeeper,
+			user:               testUser("alice", "1000", memberGroups),
+			wantErr:            "this command requires a group, but none was provided",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:               "group owner without resolved group fails closed",
+			rights:             models.GroupOwner,
+			user:               testUser("alice", "1000", memberGroups),
+			wantErr:            "this command requires a group, but none was provided",
+			wantAllowedFlipped: true,
+		},
+		{
+			name:               "unrecognized rights level fails closed",
+			rights:             models.Right(9999),
+			user:               testUser("root", "0", nil),
+			wantErr:            "unrecognized rights level 9999: refusing execution",
+			wantAllowedFlipped: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ct := testContext(tc.user, tc.group, nil)
+
+			err := newAuthorizer().authorize(tc.user, tc.rights, ct)
+
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("authorize() = %q, want success", err)
+				}
+				if !ct.Log.Allowed {
+					t.Fatalf("authorize() success must not mark the audit log not-allowed")
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("authorize() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("authorize() = %q, want %q", err, tc.wantErr)
+			}
+			if tc.wantAllowedFlipped && ct.Log.Allowed {
+				t.Fatalf("refusal must mark the audit log not-allowed")
+			}
+		})
+	}
+}
+
+// TestAuthorizeHasAccess covers the HasAccess rights level through the
+// injected access-resolution seam: the no-target mode, resolution and lookup
+// failures, refusal of an unauthorized target, and the context/audit side
+// effects of an authorized one.
+func TestAuthorizeHasAccess(t *testing.T) {
+
+	user := testUser("alice", "1000", nil)
+
+	// resolvedAccess is what the fake access builder returns: a fully resolved
+	// target, the equivalent of a successful DNS + input parse in production.
+	resolvedAccess := &models.Access{
+		Host: "db1.internal",
+		User: "app",
+		Port: 2222,
+	}
+
+	// fakeAccessBuilder mirrors production resolution: it either resolves to
+	// the given access or fails with the given error.
+	fakeAccessBuilder := func(ba *models.Access, err error) accessBuilderFunc {
+		return func(_ string) (*models.Access, error) {
+			return ba, err
+		}
+	}
+	buildOK := fakeAccessBuilder(resolvedAccess, nil)
+
+	t.Run("no access argument is allowed through without grants", func(t *testing.T) {
+		ct := testContext(user, nil, map[string]string{})
+
+		err := newAuthorizer(
+			withAccessBuilder(func(string) (*models.Access, error) {
+				t.Fatal("access builder must not be called without an access argument")
+				return nil, nil
+			}),
+			withAccessChecker(func(*models.User, *models.Access) (*models.Info, error) {
+				t.Fatal("access checker must not be called without an access argument")
+				return nil, nil
+			}),
+		).authorize(user, models.HasAccess, ct)
+
+		if err != nil {
+			t.Fatalf("authorize() = %q, want success", err)
+		}
+		if ct.AI != nil || ct.BA != nil {
+			t.Fatalf("authorize() without an access argument must leave ct.AI/ct.BA nil")
+		}
+	})
+
+	t.Run("empty access argument is allowed through without grants", func(t *testing.T) {
+		ct := testContext(user, nil, map[string]string{"access": ""})
+
+		err := newAuthorizer().authorize(user, models.HasAccess, ct)
+
+		if err != nil {
+			t.Fatalf("authorize() = %q, want success", err)
+		}
+		if ct.AI != nil || ct.BA != nil {
+			t.Fatalf("authorize() with an empty access argument must leave ct.AI/ct.BA nil")
+		}
+	})
+
+	t.Run("access resolution failure refuses", func(t *testing.T) {
+		ct := testContext(user, nil, map[string]string{"access": "app@nosuchhost"})
+		resolutionErr := errors.New("unable to resolve host")
+
+		err := newAuthorizer(
+			withAccessBuilder(fakeAccessBuilder(nil, resolutionErr)),
+		).authorize(user, models.HasAccess, ct)
+
+		if !errors.Is(err, resolutionErr) {
+			t.Fatalf("authorize() = %v, want the resolution error", err)
+		}
+		if ct.Log.Allowed {
+			t.Fatalf("a resolution failure must mark the audit log not-allowed")
+		}
+		if ct.AI != nil || ct.BA != nil {
+			t.Fatalf("a refused access must not populate ct.AI/ct.BA")
+		}
+	})
+
+	t.Run("grants lookup failure refuses", func(t *testing.T) {
+		ct := testContext(user, nil, map[string]string{"access": "app@db1.internal:2222"})
+		lookupErr := errors.New("unable to read accesses database")
+
+		err := newAuthorizer(
+			withAccessBuilder(buildOK),
+			withAccessChecker(func(*models.User, *models.Access) (*models.Info, error) {
+				return nil, lookupErr
+			}),
+		).authorize(user, models.HasAccess, ct)
+
+		if !errors.Is(err, lookupErr) {
+			t.Fatalf("authorize() = %v, want the lookup error", err)
+		}
+		if ct.Log.Allowed {
+			t.Fatalf("a grants-lookup failure must mark the audit log not-allowed")
+		}
+	})
+
+	t.Run("unauthorized target refuses and audits the attempt", func(t *testing.T) {
+		ct := testContext(user, nil, map[string]string{"access": "app@db1.internal:2222"})
+
+		err := newAuthorizer(
+			withAccessBuilder(buildOK),
+			withAccessChecker(func(*models.User, *models.Access) (*models.Info, error) {
+				return &models.Info{Authorized: false}, nil
+			}),
+		).authorize(user, models.HasAccess, ct)
+
+		if err == nil || !strings.Contains(err.Error(), "user can't access the host") {
+			t.Fatalf("authorize() = %v, want a refusal mentioning the host", err)
+		}
+		if ct.Log.Allowed {
+			t.Fatalf("an unauthorized target must mark the audit log not-allowed")
+		}
+		// Even a refused attempt records where the user tried to go.
+		if ct.Log.HostTo != "db1.internal" || ct.Log.UserTo != "app" || ct.Log.PortTo != "2222" {
+			t.Fatalf("refused attempt must still record the target, got host=%q user=%q port=%q",
+				ct.Log.HostTo, ct.Log.UserTo, ct.Log.PortTo)
+		}
+		if ct.AI != nil || ct.BA != nil {
+			t.Fatalf("a refused access must not populate ct.AI/ct.BA")
+		}
+	})
+
+	t.Run("authorized target populates the context and the audit log", func(t *testing.T) {
+		ct := testContext(user, nil, map[string]string{"access": "app@db1.internal:2222"})
+		grants := &models.Info{
+			Authorized:    true,
+			KeyFilepathes: []string{"/home/alice/.ssh/id_ed25519"},
+		}
+
+		var checkedUser *models.User
+		var checkedAccess *models.Access
+		err := newAuthorizer(
+			withAccessBuilder(buildOK),
+			withAccessChecker(func(u *models.User, ba *models.Access) (*models.Info, error) {
+				checkedUser, checkedAccess = u, ba
+				return grants, nil
+			}),
+		).authorize(user, models.HasAccess, ct)
+
+		if err != nil {
+			t.Fatalf("authorize() = %q, want success", err)
+		}
+		if checkedUser != user || checkedAccess != resolvedAccess {
+			t.Fatalf("the grants lookup must receive the subject user and the resolved access")
+		}
+		if ct.AI != grants {
+			t.Fatalf("ct.AI = %v, want the grants returned by the lookup", ct.AI)
+		}
+		if ct.BA != resolvedAccess {
+			t.Fatalf("ct.BA = %v, want the resolved access", ct.BA)
+		}
+		if !ct.Log.Allowed {
+			t.Fatalf("authorize() success must not mark the audit log not-allowed")
+		}
+		if ct.Log.HostTo != "db1.internal" || ct.Log.UserTo != "app" || ct.Log.PortTo != "2222" {
+			t.Fatalf("authorized attempt must record the target, got host=%q user=%q port=%q",
+				ct.Log.HostTo, ct.Log.UserTo, ct.Log.PortTo)
+		}
+	})
+}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -242,65 +242,12 @@ func BuildSBCommand(log *models.Log, user *models.User, args ...string) (bc Comm
 		ct.Group = grp
 	}
 
-	// Now, let's check the rights!
-	switch commandRightsLevel {
-	case models.Public:
-		// Nothing to do
-	case models.Private:
-
-		// Private commands must be run by root
-		if ct.User.User.Username != "root" {
-			err = fmt.Errorf("only root user can execute this command on sb")
-			return
-		}
-
-	case models.HasAccess:
-		host, ok := ct.FormattedArguments["access"]
-		if ok && host != "" {
-			ba, err := models.BuildSBAccessFromUserInput(host)
-			if err != nil {
-				return bc, ct, err
-			}
-
-			logAuditWarn(log.SetTargetAccess(ba))
-
-			ai, err := user.HasAccess(ba)
-			if err != nil {
-				return bc, ct, err
-			}
-			if !ai.Authorized {
-				logAuditWarn(log.SetAllowed(false))
-				return bc, ct, fmt.Errorf("user can't access the host %s", ba.ShortString())
-			}
-
-			ct.AI = ai
-			ct.BA = ba
-		}
-	case models.GroupMember:
-		if !user.IsMemberOfGroup(grp.Name) {
-			logAuditWarn(log.SetAllowed(false))
-			return bc, ct, fmt.Errorf("user is not a member of the group")
-		}
-	case models.GroupACLKeeper:
-		if !user.IsACLKeeperOfGroup(grp.Name) {
-			logAuditWarn(log.SetAllowed(false))
-			return bc, ct, fmt.Errorf("user is not an ACL keeper of the group")
-		}
-	case models.GroupGateKeeper:
-		if !user.IsGateKeeperOfGroup(grp.Name) {
-			logAuditWarn(log.SetAllowed(false))
-			return bc, ct, fmt.Errorf("user is not a gate keeper of the group")
-		}
-	case models.GroupOwner:
-		if !user.IsOwnerOfGroup(grp.Name) && !user.IsOwnerOfGroup("owners") {
-			logAuditWarn(log.SetAllowed(false))
-			return bc, ct, fmt.Errorf("user is not an owner of the group")
-		}
-	case models.SBOwner:
-		if !user.IsOwnerOfGroup("owners") && user.User.Uid != "0" {
-			logAuditWarn(log.SetAllowed(false))
-			return bc, ct, fmt.Errorf("user is not a sb owner")
-		}
+	// Now, let's check the rights! This is the single authorization gate on
+	// the dispatch path; the decision logic lives in authorize (authorize.go)
+	// so it can be unit tested hermetically.
+	err = newAuthorizer().authorize(user, commandRightsLevel, ct)
+	if err != nil {
+		return
 	}
 
 	// Call the check method


### PR DESCRIPTION
## Summary

Extracts the rights-enforcement logic out of `BuildSBCommand` into a focused, dependency-injected `authorize()` gate in `internal/commands/authorize.go`, and adds table-driven unit tests over the entire authorization matrix. This is the path that decides whether a bastion user may run a command, so it now has direct, hermetic test coverage and fails closed on its edge cases.

## Previous behavior

Rights enforcement was a `switch` inside `BuildSBCommand`, interleaved with argument parsing and group resolution, with no direct tests:

- The `HasAccess` level resolved the target (DNS) and read the per-user/per-group accesses databases inline, making the decision logic impossible to test hermetically.
- A rights level missing from the switch fell through and **allowed** execution (fail-open).
- A group-scoped level (`GroupMember`/`GroupACLKeeper`/`GroupGateKeeper`/`GroupOwner`) reaching the check without a resolved group dereferenced a nil pointer (currently shielded only by the `group` argument being declared required on those commands).
- A refused `Private` command never recorded `allowed=false` in the audit log, unlike every other refusal.

## Why it was a problem

This is the security boundary of the dispatcher: every command execution passes through it. Untested fail-open edges on that path are exactly the kind of regression a refactor can introduce silently, and inconsistent audit records make refused attempts harder to investigate.

## What changed

- New `authorizer` type holding the two effectful dependencies of the `HasAccess` level — access resolution and grants lookup — injected via a constructor with functional options; production call sites use the defaults (`models.BuildSBAccessFromUserInput`, `(*models.User).HasAccess`).
- `BuildSBCommand` now calls `authorize(user, rights, ct)` where the switch used to be. The gate keeps the switch's side effects: audit `SetAllowed(false)` on refusal, `SetTargetAccess` for the requested target (recorded even for refused attempts), and populating `ct.AI`/`ct.BA` on an authorized access.
- Fail-closed hardening: an unrecognized rights level is refused instead of falling through allowed; a group-scoped level with no resolved group is refused instead of panicking; every refusal (and internal failure on the `HasAccess` path) records `allowed=false`.
- Authorization semantics for all existing levels are otherwise unchanged, including error messages.

## How it's tested

Table-driven tests cover every rights level (`Public`, `Private`, `HasAccess`, `GroupMember`, `GroupACLKeeper`, `GroupGateKeeper`, `GroupOwner`, `SBOwner`), the `owners` super-group escalations, the root/UID-0 special cases, role-flag independence (owner without the member flag is not a member), the fail-closed paths, and the `HasAccess` seam: no-target mode, resolution/lookup failures, refusal of an unauthorized target, and the context/audit side effects of an authorized one. Tests are hermetic — no DNS, no database files (audit-log writes are exercised against a database-less log).

Test plan:
- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [x] `golangci-lint run` (0 issues)