### PR TITLE
helpers, models: fix account creation and access reads for non-root callers

### DIFF
--- a/internal/helpers/system.go
+++ b/internal/helpers/system.go
@@ -158,8 +158,56 @@ func AddUser(homedir, username, shellPath string) (err error) {
 	return
 }
 
-// CreateHomeSkeleton creates user home
+// CreateHomeSkeleton creates the home-directory layout of a freshly created
+// user or group account (its .ssh directory, databases, ttyrecs directory,
+// ...), delegating every filesystem mutation to sudo with the exact argument
+// shapes whitelisted in the sudoers templates.
+//
+// Existence is probed with os.Stat run as the *calling* user, which is often
+// an unprivileged sb owner (account and group creation are SBOwner-level
+// commands, not root-only). Such a caller typically cannot see inside the new
+// account's home directory, so a stat there fails with a permission error,
+// not with "does not exist". Only a successful stat may skip the creation
+// step: any stat failure falls back to attempting the (whitelisted, sudo-run)
+// creation. A previous version skipped creation unless the failure was
+// specifically os.IsNotExist, which silently dropped the mkdir/touch for
+// non-root callers and made the subsequent chmod fail on the missing path —
+// breaking account and group creation for everyone but root.
 func CreateHomeSkeleton(homedir string, username string, homeType string) (err error) {
+
+	commands, err := homeSkeletonCommands(homedir, username, homeType, func(path string) bool {
+		_, statErr := os.Stat(path)
+		return statErr == nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, command := range commands {
+		err := runCommand(command[0], command[1:]...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}
+
+// homeSkeletonCommands computes the ordered list of privileged commands that
+// lay out a user or group home skeleton. It is pure (no filesystem access, no
+// exec) so the command plan can be unit tested: the pathExists probe is
+// injected by the caller precisely because probing is caller-dependent (see
+// CreateHomeSkeleton). Each returned command is an argv slice starting with
+// /usr/bin/sudo, and every shape must stay in lockstep with the sudoers
+// templates in templates.go — a command that drifts from the whitelist fails
+// in production.
+//
+// homeType selects the layout ("user" or "group"); any other value returns an
+// error. Creation commands run as the target username via sudo -u and are
+// emitted only when pathExists cannot positively confirm the path; chmod and
+// chown always run so ownership and modes converge even on pre-existing
+// paths.
+func homeSkeletonCommands(homedir, username, homeType string, pathExists func(string) bool) (commands [][]string, err error) {
 
 	type pathConfiguration struct {
 		action string
@@ -186,15 +234,18 @@ func CreateHomeSkeleton(homedir string, username string, homeType string) (err e
 			pathConfiguration{action: "/usr/bin/touch", path: "accesses.db", chmod: "0664", chown: fmt.Sprintf("%s:%s-aclk", username, username)},
 		)
 	default:
-		return fmt.Errorf("invalid home type %s", homeType)
+		return nil, fmt.Errorf("invalid home type %s", homeType)
 	}
 
+	commands = make([][]string, 0, 3*len(pathConfigurations))
 	for _, pathConf := range pathConfigurations {
 		fullPath := fmt.Sprintf("%s/%s", homedir, pathConf.path)
-		commands := make([][]string, 0)
 
-		// If path doesn't exist, we create it
-		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		// Create the path unless it positively exists. Failing toward
+		// creation is the safe direction: the creation command is whitelisted
+		// in sudoers and fails loudly if the path is truly already there,
+		// whereas skipping it leaves the skeleton incomplete.
+		if !pathExists(fullPath) {
 			commands = append(commands, []string{"/usr/bin/sudo", "-u", username, pathConf.action, fullPath})
 		}
 
@@ -203,15 +254,9 @@ func CreateHomeSkeleton(homedir string, username string, homeType string) (err e
 			[]string{"/usr/bin/sudo", "/bin/chmod", pathConf.chmod, fullPath},
 			[]string{"/usr/bin/sudo", "/bin/chown", pathConf.chown, fullPath},
 		)
-		for _, command := range commands {
-			err := runCommand(command[0], command[1:]...)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
-	return
+	return commands, nil
 }
 
 // DeleteAccount deletes a group from the system

--- a/internal/helpers/system_homeskeleton_test.go
+++ b/internal/helpers/system_homeskeleton_test.go
@@ -1,0 +1,120 @@
+package helpers
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestHomeSkeletonCommands pins the exact privileged command plan of the home
+// skeleton creation: which sudo commands run, in which order, with which
+// argument shapes. The shapes double as a regression guard for the sudoers
+// whitelist in templates.go — a command emitted here that the templates do
+// not allow fails in production.
+func TestHomeSkeletonCommands(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		homedir  string
+		username string
+		homeType string
+		// exists is the injected pathExists probe result for every path.
+		exists  bool
+		want    [][]string
+		wantErr bool
+	}{
+		{
+			// pathExists returning false covers both "does not exist" and
+			// "cannot be probed" (a non-root caller who cannot see inside
+			// the new home): in both cases creation must be attempted, never
+			// silently skipped. The latter is the regression case where
+			// account creation by a non-root sb owner used to break.
+			name:     "user skeleton on a fresh or unprobeable home creates everything",
+			homedir:  "/home/t1000",
+			username: "t1000",
+			homeType: "user",
+			exists:   false,
+			want: [][]string{
+				{"/usr/bin/sudo", "-u", "t1000", "/bin/mkdir", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "-u", "t1000", "/bin/mkdir", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "-u", "t1000", "/usr/bin/touch", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "-u", "t1000", "/usr/bin/touch", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "-u", "t1000", "/usr/bin/touch", "/home/t1000/.ssh/authorized_keys"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/.ssh/authorized_keys"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/.ssh/authorized_keys"},
+			},
+		},
+		{
+			name:     "user skeleton on an existing home only converges modes and owners",
+			homedir:  "/home/t1000",
+			username: "t1000",
+			homeType: "user",
+			exists:   true,
+			want: [][]string{
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/.ssh/authorized_keys"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/.ssh/authorized_keys"},
+			},
+		},
+		{
+			name:     "group skeleton on a fresh home creates everything",
+			homedir:  "/home/bg_redteam",
+			username: "bg_redteam",
+			homeType: "group",
+			exists:   false,
+			want: [][]string{
+				{"/usr/bin/sudo", "-u", "bg_redteam", "/bin/mkdir", "/home/bg_redteam/"},
+				{"/usr/bin/sudo", "/bin/chmod", "0775", "/home/bg_redteam/"},
+				{"/usr/bin/sudo", "/bin/chown", "bg_redteam:bg_redteam-aclk", "/home/bg_redteam/"},
+				{"/usr/bin/sudo", "-u", "bg_redteam", "/bin/mkdir", "/home/bg_redteam/.ssh"},
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/bg_redteam/.ssh"},
+				{"/usr/bin/sudo", "/bin/chown", "bg_redteam:bg_redteam", "/home/bg_redteam/.ssh"},
+				{"/usr/bin/sudo", "-u", "bg_redteam", "/usr/bin/touch", "/home/bg_redteam/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0664", "/home/bg_redteam/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chown", "bg_redteam:bg_redteam-aclk", "/home/bg_redteam/accesses.db"},
+			},
+		},
+		{
+			name:     "unknown home type is refused",
+			homedir:  "/home/x",
+			username: "x",
+			homeType: "device",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := homeSkeletonCommands(tc.homedir, tc.username, tc.homeType, func(string) bool {
+				return tc.exists
+			})
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("homeSkeletonCommands() = nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("homeSkeletonCommands() error = %v, want success", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("homeSkeletonCommands() plan mismatch:\ngot:  %v\nwant: %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -20,10 +20,23 @@ func GetAccessGormDB(database string) (db *gorm.DB, err error) {
 		return
 	}
 
-	// Migrate the schema (this will create table or alter table if needed)
+	// Migrate the schema (this will create table or alter table if needed).
+	// Migration is a write, and not every legitimate caller may write this
+	// database: a group's accesses database is writable by its ACL keepers
+	// only, while plain members open it read-only (listing the group's
+	// accesses, resolving a group-granted host connection). For such readers
+	// the migration fails with a read-only error even though the schema is
+	// already in place. Only tolerate that failure when the table verifiably
+	// exists: the database was then provisioned by a writable caller, and a
+	// genuinely incompatible schema still surfaces as a loud query error. An
+	// unprovisioned database (no table) keeps failing here, read-only or not.
 	if err = db.AutoMigrate(&Access{}); err != nil {
-		err = fmt.Errorf("failed to migrate access schema for %s: %w", database, err)
-		return
+		if db.Migrator().HasTable(&Access{}) {
+			err = nil
+		} else {
+			err = fmt.Errorf("failed to migrate access schema for %s: %w", database, err)
+			return
+		}
 	}
 
 	return

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetAccessGormDBReadOnly covers opening an accesses database without
+// write permission, the situation of every plain group member reading the
+// group's accesses (the file is writable by the group's ACL keepers only):
+// a provisioned database must open and serve reads, while an unprovisioned
+// one must keep failing — its schema cannot be created without writing.
+func TestGetAccessGormDBReadOnly(t *testing.T) {
+
+	t.Run("provisioned database opens and reads without write permission", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "accesses.db")
+
+		// Provision the database as a writable caller (the ACL-keeper role
+		// in production): schema migrated and one access stored.
+		db, err := GetAccessGormDB(dbPath)
+		if err != nil {
+			t.Fatalf("provisioning open failed: %v", err)
+		}
+		if err := db.Create(&Access{Host: "examplevm", User: "root", Port: 22}).Error; err != nil {
+			t.Fatalf("provisioning insert failed: %v", err)
+		}
+		sqlDB, err := db.DB()
+		if err != nil {
+			t.Fatalf("unable to get SQL handle: %v", err)
+		}
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("unable to close provisioning handle: %v", err)
+		}
+
+		// Drop write permission, as seen by a plain group member.
+		if err := os.Chmod(dbPath, 0o444); err != nil {
+			t.Fatalf("unable to chmod database read-only: %v", err)
+		}
+
+		// Re-open read-only: the migration write fails, but the schema is in
+		// place, so the open must succeed and reads must work.
+		roDB, err := GetAccessGormDB(dbPath)
+		if err != nil {
+			t.Fatalf("read-only open of a provisioned database failed: %v", err)
+		}
+		accesses, err := GetAllAccesses(roDB)
+		if err != nil {
+			t.Fatalf("read-only query failed: %v", err)
+		}
+		if len(accesses) != 1 || accesses[0].Host != "examplevm" {
+			t.Fatalf("read-only query returned %v, want the provisioned access", accesses)
+		}
+	})
+
+	t.Run("unprovisioned read-only database still fails", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "accesses.db")
+
+		// An empty file with no schema, not writable: the table cannot be
+		// created, so opening must fail rather than hand out a handle that
+		// breaks on first use.
+		if err := os.WriteFile(dbPath, nil, 0o444); err != nil {
+			t.Fatalf("unable to create empty database file: %v", err)
+		}
+
+		if _, err := GetAccessGormDB(dbPath); err == nil {
+			t.Fatalf("open of an unprovisioned read-only database succeeded, want error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Two fixes for privileged-but-not-root callers, both found by exercising the bastion as a regular sb owner and as a plain group member instead of root:

1. `CreateHomeSkeleton` silently skipped creating home-skeleton paths whenever the caller could not probe them, breaking `account create` / `group create` for every caller except root.
2. `GetAccessGormDB` required write access to open an accesses database, locking plain group members out of reading the group's accesses — including `HasAccess` resolving a group-granted host connection.

## Previous behavior

- `CreateHomeSkeleton` decided whether to create each path (`.ssh`, `ttyrecs`, `accesses.db`, …) by running `os.Stat` **as the calling user** and creating only on `os.IsNotExist`. Account and group creation are SBOwner-level commands, so the caller is usually an unprivileged owner account that cannot see inside the new home: the stat failed with a permission error instead, the `mkdir`/`touch` was skipped, and the subsequent `chmod` failed on the missing path. Creation worked only for root (which is how the demo image bootstraps, so it never showed).
- `GetAccessGormDB` unconditionally ran GORM `AutoMigrate` (a write) and failed the open when it failed. A group's accesses database is writable by its ACL keepers only (`0664 group:group-aclk`); plain members open it read-only and always got *"attempt to write a readonly database"*.

## What changed

- `CreateHomeSkeleton` now plans its commands via a pure `homeSkeletonCommands` function with an injected `pathExists` probe, and the decision is inverted: only a *successful* stat may skip creation; any failure falls back to attempting it. Failing toward creation is safe — the creation commands are exactly the shapes whitelisted in the sudoers templates (unchanged by this PR) and fail loudly if the path truly exists.
- `GetAccessGormDB` tolerates a failed migration **iff** the accesses table verifiably exists (the schema was provisioned by a writable caller, i.e. the first ACL-keeper write); an unprovisioned database keeps failing the open, and a genuinely incompatible schema still surfaces as a query error.

## How it's tested

- Table test pinning the full privileged command plan of user and group skeletons (fresh home, pre-existing home, unknown home type) — which also guards the sudo argument shapes against drifting from the sudoers whitelist.
- Unit test that provisions an accesses database, drops its write permission, and asserts the read-only re-open succeeds and serves the stored access; plus the unprovisioned read-only database still refusing to open.
- Verified end-to-end on the local demo stack: an sb owner creates an account over SSH, and a plain group member lists the group's accesses. e2e coverage asserting these flows in CI lands in a follow-up that builds on this PR.
- `go build ./...`, `go test ./...`, `golangci-lint run` all green.

## Test plan

- [x] `go test ./internal/helpers/ -run TestHomeSkeletonCommands`
- [x] `go test ./internal/models/ -run TestGetAccessGormDBReadOnly`
- [x] Full local e2e run against the demo stack (`tests/e2e.sh`)