### PR TITLE
tests: cover the authorization matrix in the e2e suite

### DIFF
--- a/internal/helpers/system.go
+++ b/internal/helpers/system.go
@@ -158,8 +158,56 @@ func AddUser(homedir, username, shellPath string) (err error) {
 	return
 }
 
-// CreateHomeSkeleton creates user home
+// CreateHomeSkeleton creates the home-directory layout of a freshly created
+// user or group account (its .ssh directory, databases, ttyrecs directory,
+// ...), delegating every filesystem mutation to sudo with the exact argument
+// shapes whitelisted in the sudoers templates.
+//
+// Existence is probed with os.Stat run as the *calling* user, which is often
+// an unprivileged sb owner (account and group creation are SBOwner-level
+// commands, not root-only). Such a caller typically cannot see inside the new
+// account's home directory, so a stat there fails with a permission error,
+// not with "does not exist". Only a successful stat may skip the creation
+// step: any stat failure falls back to attempting the (whitelisted, sudo-run)
+// creation. A previous version skipped creation unless the failure was
+// specifically os.IsNotExist, which silently dropped the mkdir/touch for
+// non-root callers and made the subsequent chmod fail on the missing path —
+// breaking account and group creation for everyone but root.
 func CreateHomeSkeleton(homedir string, username string, homeType string) (err error) {
+
+	commands, err := homeSkeletonCommands(homedir, username, homeType, func(path string) bool {
+		_, statErr := os.Stat(path)
+		return statErr == nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, command := range commands {
+		err := runCommand(command[0], command[1:]...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}
+
+// homeSkeletonCommands computes the ordered list of privileged commands that
+// lay out a user or group home skeleton. It is pure (no filesystem access, no
+// exec) so the command plan can be unit tested: the pathExists probe is
+// injected by the caller precisely because probing is caller-dependent (see
+// CreateHomeSkeleton). Each returned command is an argv slice starting with
+// /usr/bin/sudo, and every shape must stay in lockstep with the sudoers
+// templates in templates.go — a command that drifts from the whitelist fails
+// in production.
+//
+// homeType selects the layout ("user" or "group"); any other value returns an
+// error. Creation commands run as the target username via sudo -u and are
+// emitted only when pathExists cannot positively confirm the path; chmod and
+// chown always run so ownership and modes converge even on pre-existing
+// paths.
+func homeSkeletonCommands(homedir, username, homeType string, pathExists func(string) bool) (commands [][]string, err error) {
 
 	type pathConfiguration struct {
 		action string
@@ -186,15 +234,18 @@ func CreateHomeSkeleton(homedir string, username string, homeType string) (err e
 			pathConfiguration{action: "/usr/bin/touch", path: "accesses.db", chmod: "0664", chown: fmt.Sprintf("%s:%s-aclk", username, username)},
 		)
 	default:
-		return fmt.Errorf("invalid home type %s", homeType)
+		return nil, fmt.Errorf("invalid home type %s", homeType)
 	}
 
+	commands = make([][]string, 0, 3*len(pathConfigurations))
 	for _, pathConf := range pathConfigurations {
 		fullPath := fmt.Sprintf("%s/%s", homedir, pathConf.path)
-		commands := make([][]string, 0)
 
-		// If path doesn't exist, we create it
-		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		// Create the path unless it positively exists. Failing toward
+		// creation is the safe direction: the creation command is whitelisted
+		// in sudoers and fails loudly if the path is truly already there,
+		// whereas skipping it leaves the skeleton incomplete.
+		if !pathExists(fullPath) {
 			commands = append(commands, []string{"/usr/bin/sudo", "-u", username, pathConf.action, fullPath})
 		}
 
@@ -203,15 +254,9 @@ func CreateHomeSkeleton(homedir string, username string, homeType string) (err e
 			[]string{"/usr/bin/sudo", "/bin/chmod", pathConf.chmod, fullPath},
 			[]string{"/usr/bin/sudo", "/bin/chown", pathConf.chown, fullPath},
 		)
-		for _, command := range commands {
-			err := runCommand(command[0], command[1:]...)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
-	return
+	return commands, nil
 }
 
 // DeleteAccount deletes a group from the system

--- a/internal/helpers/system_homeskeleton_test.go
+++ b/internal/helpers/system_homeskeleton_test.go
@@ -1,0 +1,120 @@
+package helpers
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestHomeSkeletonCommands pins the exact privileged command plan of the home
+// skeleton creation: which sudo commands run, in which order, with which
+// argument shapes. The shapes double as a regression guard for the sudoers
+// whitelist in templates.go — a command emitted here that the templates do
+// not allow fails in production.
+func TestHomeSkeletonCommands(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		homedir  string
+		username string
+		homeType string
+		// exists is the injected pathExists probe result for every path.
+		exists  bool
+		want    [][]string
+		wantErr bool
+	}{
+		{
+			// pathExists returning false covers both "does not exist" and
+			// "cannot be probed" (a non-root caller who cannot see inside
+			// the new home): in both cases creation must be attempted, never
+			// silently skipped. The latter is the regression case where
+			// account creation by a non-root sb owner used to break.
+			name:     "user skeleton on a fresh or unprobeable home creates everything",
+			homedir:  "/home/t1000",
+			username: "t1000",
+			homeType: "user",
+			exists:   false,
+			want: [][]string{
+				{"/usr/bin/sudo", "-u", "t1000", "/bin/mkdir", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "-u", "t1000", "/bin/mkdir", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "-u", "t1000", "/usr/bin/touch", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "-u", "t1000", "/usr/bin/touch", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "-u", "t1000", "/usr/bin/touch", "/home/t1000/.ssh/authorized_keys"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/.ssh/authorized_keys"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/.ssh/authorized_keys"},
+			},
+		},
+		{
+			name:     "user skeleton on an existing home only converges modes and owners",
+			homedir:  "/home/t1000",
+			username: "t1000",
+			homeType: "user",
+			exists:   true,
+			want: [][]string{
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/.ssh"},
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/ttyrecs"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/logs.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0640", "/home/t1000/.ssh/authorized_keys"},
+				{"/usr/bin/sudo", "/bin/chown", "t1000:t1000", "/home/t1000/.ssh/authorized_keys"},
+			},
+		},
+		{
+			name:     "group skeleton on a fresh home creates everything",
+			homedir:  "/home/bg_redteam",
+			username: "bg_redteam",
+			homeType: "group",
+			exists:   false,
+			want: [][]string{
+				{"/usr/bin/sudo", "-u", "bg_redteam", "/bin/mkdir", "/home/bg_redteam/"},
+				{"/usr/bin/sudo", "/bin/chmod", "0775", "/home/bg_redteam/"},
+				{"/usr/bin/sudo", "/bin/chown", "bg_redteam:bg_redteam-aclk", "/home/bg_redteam/"},
+				{"/usr/bin/sudo", "-u", "bg_redteam", "/bin/mkdir", "/home/bg_redteam/.ssh"},
+				{"/usr/bin/sudo", "/bin/chmod", "0755", "/home/bg_redteam/.ssh"},
+				{"/usr/bin/sudo", "/bin/chown", "bg_redteam:bg_redteam", "/home/bg_redteam/.ssh"},
+				{"/usr/bin/sudo", "-u", "bg_redteam", "/usr/bin/touch", "/home/bg_redteam/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chmod", "0664", "/home/bg_redteam/accesses.db"},
+				{"/usr/bin/sudo", "/bin/chown", "bg_redteam:bg_redteam-aclk", "/home/bg_redteam/accesses.db"},
+			},
+		},
+		{
+			name:     "unknown home type is refused",
+			homedir:  "/home/x",
+			username: "x",
+			homeType: "device",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := homeSkeletonCommands(tc.homedir, tc.username, tc.homeType, func(string) bool {
+				return tc.exists
+			})
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("homeSkeletonCommands() = nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("homeSkeletonCommands() error = %v, want success", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("homeSkeletonCommands() plan mismatch:\ngot:  %v\nwant: %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -20,10 +20,23 @@ func GetAccessGormDB(database string) (db *gorm.DB, err error) {
 		return
 	}
 
-	// Migrate the schema (this will create table or alter table if needed)
+	// Migrate the schema (this will create table or alter table if needed).
+	// Migration is a write, and not every legitimate caller may write this
+	// database: a group's accesses database is writable by its ACL keepers
+	// only, while plain members open it read-only (listing the group's
+	// accesses, resolving a group-granted host connection). For such readers
+	// the migration fails with a read-only error even though the schema is
+	// already in place. Only tolerate that failure when the table verifiably
+	// exists: the database was then provisioned by a writable caller, and a
+	// genuinely incompatible schema still surfaces as a loud query error. An
+	// unprovisioned database (no table) keeps failing here, read-only or not.
 	if err = db.AutoMigrate(&Access{}); err != nil {
-		err = fmt.Errorf("failed to migrate access schema for %s: %w", database, err)
-		return
+		if db.Migrator().HasTable(&Access{}) {
+			err = nil
+		} else {
+			err = fmt.Errorf("failed to migrate access schema for %s: %w", database, err)
+			return
+		}
 	}
 
 	return

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetAccessGormDBReadOnly covers opening an accesses database without
+// write permission, the situation of every plain group member reading the
+// group's accesses (the file is writable by the group's ACL keepers only):
+// a provisioned database must open and serve reads, while an unprovisioned
+// one must keep failing — its schema cannot be created without writing.
+func TestGetAccessGormDBReadOnly(t *testing.T) {
+
+	t.Run("provisioned database opens and reads without write permission", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "accesses.db")
+
+		// Provision the database as a writable caller (the ACL-keeper role
+		// in production): schema migrated and one access stored.
+		db, err := GetAccessGormDB(dbPath)
+		if err != nil {
+			t.Fatalf("provisioning open failed: %v", err)
+		}
+		if err := db.Create(&Access{Host: "examplevm", User: "root", Port: 22}).Error; err != nil {
+			t.Fatalf("provisioning insert failed: %v", err)
+		}
+		sqlDB, err := db.DB()
+		if err != nil {
+			t.Fatalf("unable to get SQL handle: %v", err)
+		}
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("unable to close provisioning handle: %v", err)
+		}
+
+		// Drop write permission, as seen by a plain group member.
+		if err := os.Chmod(dbPath, 0o444); err != nil {
+			t.Fatalf("unable to chmod database read-only: %v", err)
+		}
+
+		// Re-open read-only: the migration write fails, but the schema is in
+		// place, so the open must succeed and reads must work.
+		roDB, err := GetAccessGormDB(dbPath)
+		if err != nil {
+			t.Fatalf("read-only open of a provisioned database failed: %v", err)
+		}
+		accesses, err := GetAllAccesses(roDB)
+		if err != nil {
+			t.Fatalf("read-only query failed: %v", err)
+		}
+		if len(accesses) != 1 || accesses[0].Host != "examplevm" {
+			t.Fatalf("read-only query returned %v, want the provisioned access", accesses)
+		}
+	})
+
+	t.Run("unprovisioned read-only database still fails", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "accesses.db")
+
+		// An empty file with no schema, not writable: the table cannot be
+		// created, so opening must fail rather than hand out a handle that
+		// breaks on first use.
+		if err := os.WriteFile(dbPath, nil, 0o444); err != nil {
+			t.Fatalf("unable to create empty database file: %v", err)
+		}
+
+		if _, err := GetAccessGormDB(dbPath); err == nil {
+			t.Fatalf("open of an unprovisioned read-only database succeeded, want error")
+		}
+	})
+}

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -94,4 +94,123 @@ if ! sb1 root@examplevm -- cat docs/demo.md | grep -q "# Demo"; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# Permission checks
+#
+# t800 (created at image build time) owns the "owners" super-group, so every
+# check above runs with full privileges. The checks below create a second,
+# unprivileged account (t1000) and assert that each rights level actually
+# refuses it, then that an explicit role grant lifts exactly the matching
+# refusal. Every probe passes all required arguments so it reaches the
+# authorization check instead of failing earlier on argument validation.
+# ---------------------------------------------------------------------------
+
+echo "Create an unprivileged account t1000 (as the sb owner t800)"
+
+# The key is wrapped in literal single quotes: ssh flattens its arguments into
+# one remote command string, and the quotes keep the multi-word key a single
+# argument for the bastion's own command-line parser.
+if ! sb1 account create --username t1000 --public-key "'$(cat "$(pwd)/demo/assets/ssh-keys/id_ed25519.pub")'"; then
+    echo "Unable to create the unprivileged account t1000";
+    exit 1;
+fi
+
+# t1000 uses the same demo key pair as t800, only the account differs
+alias sb1u="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 22001 t1000@127.0.0.1 -A -tt -- "
+
+echo "Check that a non-owner cannot create accounts (SBOwner level)"
+
+if ! sb1u account create --username eve --public-key "irrelevant" | grep -q "user is not a sb owner"; then
+    echo "t1000 should not be able to create accounts";
+    exit 1;
+fi
+
+echo "Check that a non-owner cannot create groups (SBOwner level)"
+
+if ! sb1u group create --name evilcorp --owner-account t1000 --algo ed25519 --size 256 | grep -q "user is not a sb owner"; then
+    echo "t1000 should not be able to create groups";
+    exit 1;
+fi
+
+echo "Check that even the sb owner cannot run root-only commands (Private level)"
+
+if ! sb1 backup --backup-directory /tmp | grep -q "only root user can execute this command"; then
+    echo "t800 should not be able to run the root-only backup command";
+    exit 1;
+fi
+
+echo "Create the group redteam owned by t800 (group-level checks fixture)"
+
+if ! sb1 group create --name redteam --owner-account t800 --algo ed25519 --size 256; then
+    echo "Unable to create the redteam group";
+    exit 1;
+fi
+
+echo "Check that the ACL keeper can grant the group an access (GroupACLKeeper level)"
+
+# t800 holds every role on redteam (group creation grants the owner account
+# all of them). Granting an access here also writes the group's accesses
+# database schema: the file starts empty, and the first write must come from
+# an ACL keeper — a plain member only has read permission on it.
+if ! sb1 group access add --group redteam --host examplevm --user root --port 22; then
+    echo "t800, an ACL keeper of redteam, should be able to grant it an access";
+    exit 1;
+fi
+
+echo "Check that a non-member cannot list the group's accesses (GroupMember level)"
+
+if ! sb1u group accesses list --group redteam | grep -q "user is not a member of the group"; then
+    echo "t1000 should not be able to list redteam's accesses";
+    exit 1;
+fi
+
+echo "Check that a non-gate-keeper cannot add members (GroupGateKeeper level)"
+
+if ! sb1u group member add --group redteam --account t1000 | grep -q "user is not a gate keeper of the group"; then
+    echo "t1000 should not be able to add itself as a redteam member";
+    exit 1;
+fi
+
+echo "Check that a non-ACL-keeper cannot grant accesses (GroupACLKeeper level)"
+
+if ! sb1u group access add --group redteam --host examplevm --user root --port 22 | grep -q "user is not an ACL keeper of the group"; then
+    echo "t1000 should not be able to grant accesses to redteam";
+    exit 1;
+fi
+
+echo "Check that a non-owner cannot add owners (GroupOwner level)"
+
+if ! sb1u group owner add --group redteam --account t1000 | grep -q "user is not an owner of the group"; then
+    echo "t1000 should not be able to make itself a redteam owner";
+    exit 1;
+fi
+
+echo "Grant t1000 the gate-keeper role on redteam (as the group owner t800)"
+
+if ! sb1 group gate-keeper add --group redteam --account t1000; then
+    echo "t800 should be able to add t1000 as a redteam gate keeper";
+    exit 1;
+fi
+
+echo "Check that the gate keeper can now add members (GroupGateKeeper level)"
+
+if ! sb1u group member add --group redteam --account t1000; then
+    echo "t1000, now a gate keeper, should be able to add itself as a redteam member";
+    exit 1;
+fi
+
+echo "Check that the member can now list the group's accesses (GroupMember level)"
+
+if ! sb1u group accesses list --group redteam | grep -q "examplevm"; then
+    echo "t1000, now a member, should be able to list redteam's accesses";
+    exit 1;
+fi
+
+echo "Check that the gate keeper still cannot grant accesses (roles are independent)"
+
+if ! sb1u group access add --group redteam --host examplevm --user root --port 22 | grep -q "user is not an ACL keeper of the group"; then
+    echo "t1000's gate-keeper role should not grant ACL-keeper rights";
+    exit 1;
+fi
+
 exit 0;


### PR DESCRIPTION
## Summary

Extends the CI e2e suite with permission checks covering every rights level the command dispatcher enforces. Until now the suite ran everything as `t800` — an account that owns the `owners` super-group, i.e. with full privileges — so the only authorization behavior under test was the refusal of an unauthorized host connection.

## Previous behavior

The e2e suite never exercised an unprivileged account. Nothing verified that the rights levels gating commands (sb owner, root-only, group member / gate keeper / ACL keeper / owner) actually refuse an account that doesn't hold them, nor that granting a role lifts exactly the matching refusal. A regression letting any account create accounts or self-escalate group roles would have sailed through CI.

## What changed

The suite now creates a second, unprivileged account `t1000` over SSH (as `t800`, proving non-root account creation works end-to-end) and asserts:

**Refusals** — each probe passes all required arguments so it reaches the authorization check rather than failing earlier on argument validation:
- `account create` and `group create` as `t1000` → refused (SBOwner)
- `backup` as `t800` → refused even for the sb owner (Private, root-only)
- on a fresh `redteam` group owned by `t800`: `group accesses list`, `group member add`, `group access add`, `group owner add` as `t1000` → each refused with its level's message (GroupMember, GroupGateKeeper, GroupACLKeeper, GroupOwner)

**Grants take effect and stay scoped:**
- `t800` (ACL keeper) grants the group an access — this also provisions the group's accesses database, whose first write must come from an ACL keeper
- `t800` (owner) makes `t1000` a gate keeper → `t1000` can now add itself as a member → as a member it lists the group's accesses and sees the grant
- the gate-keeper role still cannot grant accesses — roles are independent flags

The `t1000` public key is wrapped in literal quotes because ssh flattens its arguments into a single command string and the bastion's parser must see the multi-word key as one argument.

## How it's tested

This is the test. Verified green twice against the local demo stack (fresh builds): once on this branch, and once with the in-flight authorization-refactor branch merged in to confirm the matrix holds across that change. The script is the same `tests/e2e.sh` CI runs on every PR.