### PR TITLE
commands: collapse Execute into a typed Result and a single error

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -43,7 +43,7 @@ func (c *Backup) Checks(ct *commands.Context) (err error) {
 	return
 }
 
-func (c *Backup) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Backup) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	hostname, err := helpers.GetHostname()
 	if err != nil {

--- a/cmd/createAccount.go
+++ b/cmd/createAccount.go
@@ -67,16 +67,16 @@ func (c *CreateAccount) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *CreateAccount) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *CreateAccount) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"username":   ct.FormattedArguments["username"],
 		"public-key": c.PK.String(),
 	}
-	repl["home-dir"] = fmt.Sprintf("/home/%s", repl["username"])
-	repl["ssh-dir"] = fmt.Sprintf("%s/.ssh", repl["home-dir"])
+	res.Repl["home-dir"] = fmt.Sprintf("/home/%s", res.Repl["username"])
+	res.Repl["ssh-dir"] = fmt.Sprintf("%s/.ssh", res.Repl["home-dir"])
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/createGroup.go
+++ b/cmd/createGroup.go
@@ -111,7 +111,7 @@ func (c *CreateGroup) Checks(ct *commands.Context) (err error) {
 }
 
 // Execute executes the command
-func (c *CreateGroup) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *CreateGroup) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	// Ask for the passphrase if requested
 	passphrase, ok := ct.FormattedArguments["encrypted"]
@@ -152,7 +152,7 @@ func (c *CreateGroup) Execute(ct *commands.Context) (repl models.ReplicationData
 	}
 
 	// We gathered all required data without modifying the system
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"name":             ct.FormattedArguments["name"],
 		"owner-account":    ct.FormattedArguments["owner-account"],
 		"files-owner":      filesOwner,
@@ -163,7 +163,7 @@ func (c *CreateGroup) Execute(ct *commands.Context) (repl models.ReplicationData
 	}
 
 	// Let's let the replication function do all the heavy lifting with the provided data
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -43,7 +43,7 @@ func (c *Daemon) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *Daemon) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Daemon) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	// IF replication is not enabled, nothing to do
 	replicationQueueConfig := config.GetReplicationQueueConfig()
@@ -51,7 +51,7 @@ func (c *Daemon) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 
 	// If both replication and ttyrecs offloading is disabled, nothing to do
 	if !replicationQueueConfig.Enabled && !ttyrecsOffloadingConfig.Enabled {
-		return repl, cmdError, types.ErrCommandDisabled
+		return res, types.ErrCommandDisabled
 	}
 
 	// Fail closed before touching the network: both of the features handled by
@@ -62,7 +62,7 @@ func (c *Daemon) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 	// path deliberately does not run this check, so a default key never locks
 	// users out of the bastion shell; it only stops the exfiltrating daemon.
 	if err = config.ValidateSecretsEncryption(); err != nil {
-		return repl, cmdError, err
+		return res, err
 	}
 
 	// We need to guess our own hostname

--- a/cmd/delAccount.go
+++ b/cmd/delAccount.go
@@ -57,14 +57,14 @@ func (c *DelAccount) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *DelAccount) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *DelAccount) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account":        ct.FormattedArguments["account"],
 		"archive-suffix": fmt.Sprintf("bak_%d", time.Now().Unix()),
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/delGroup.go
+++ b/cmd/delGroup.go
@@ -48,14 +48,14 @@ func (c *DelGroup) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *DelGroup) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *DelGroup) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":          ct.FormattedArguments["group"],
 		"archive-suffix": fmt.Sprintf("bak_%d", time.Now().Unix()),
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupAddACLKeeper.go
+++ b/cmd/groupAddACLKeeper.go
@@ -51,14 +51,14 @@ func (c *GroupAddACLKeeper) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupAddACLKeeper) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupAddACLKeeper) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.FormattedArguments["group"],
 		"account": ct.FormattedArguments["account"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupAddAccess.go
+++ b/cmd/groupAddAccess.go
@@ -68,9 +68,9 @@ func (c *GroupAddAccess) PostExecute(repl models.ReplicationData) (err error) {
 }
 
 // Execute executes the command
-func (c *GroupAddAccess) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupAddAccess) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.Group.Name,
 		"host":    ct.FormattedArguments["host"],
 		"user":    ct.FormattedArguments["user"],
@@ -79,7 +79,7 @@ func (c *GroupAddAccess) Execute(ct *commands.Context) (repl models.ReplicationD
 		"comment": fmt.Sprintf("Access granted by %s on %s", ct.User.User.Username, time.Now().Format(time.RFC3339)),
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupAddGateKeeper.go
+++ b/cmd/groupAddGateKeeper.go
@@ -51,14 +51,14 @@ func (c *GroupAddGateKeeper) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupAddGateKeeper) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupAddGateKeeper) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.FormattedArguments["group"],
 		"account": ct.FormattedArguments["account"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupAddMember.go
+++ b/cmd/groupAddMember.go
@@ -51,14 +51,14 @@ func (c *GroupAddMember) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupAddMember) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupAddMember) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.FormattedArguments["group"],
 		"account": ct.FormattedArguments["account"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupAddOwner.go
+++ b/cmd/groupAddOwner.go
@@ -51,14 +51,14 @@ func (c *GroupAddOwner) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupAddOwner) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupAddOwner) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.FormattedArguments["group"],
 		"account": ct.FormattedArguments["account"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupDelACLKeeper.go
+++ b/cmd/groupDelACLKeeper.go
@@ -51,14 +51,14 @@ func (c *GroupDelACLKeeper) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupDelACLKeeper) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupDelACLKeeper) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.FormattedArguments["group"],
 		"account": ct.FormattedArguments["account"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupDelAccess.go
+++ b/cmd/groupDelAccess.go
@@ -49,16 +49,16 @@ func (c *GroupDelAccess) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupDelAccess) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupDelAccess) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group": ct.Group.Name,
 		"host":  ct.FormattedArguments["host"],
 		"user":  ct.FormattedArguments["user"],
 		"port":  ct.FormattedArguments["port"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupDelGateKeeper.go
+++ b/cmd/groupDelGateKeeper.go
@@ -51,14 +51,14 @@ func (c *GroupDelGateKeeper) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupDelGateKeeper) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupDelGateKeeper) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.FormattedArguments["group"],
 		"account": ct.FormattedArguments["account"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupDelMember.go
+++ b/cmd/groupDelMember.go
@@ -51,14 +51,14 @@ func (c *GroupDelMember) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupDelMember) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupDelMember) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.FormattedArguments["group"],
 		"account": ct.FormattedArguments["account"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupDelOwner.go
+++ b/cmd/groupDelOwner.go
@@ -51,14 +51,14 @@ func (c *GroupDelOwner) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupDelOwner) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupDelOwner) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"group":   ct.FormattedArguments["group"],
 		"account": ct.FormattedArguments["account"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/groupGenerateEgressKey.go
+++ b/cmd/groupGenerateEgressKey.go
@@ -80,7 +80,7 @@ func (c *GroupGenerateEgressKey) Checks(ct *commands.Context) (err error) {
 }
 
 // Execute executes the command
-func (c *GroupGenerateEgressKey) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupGenerateEgressKey) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	passphrase, ok := ct.FormattedArguments["encrypted"]
 	if ok {
@@ -118,7 +118,7 @@ func (c *GroupGenerateEgressKey) Execute(ct *commands.Context) (repl models.Repl
 		return
 	}
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"files-owner":      filesOwner,
 		"private-key":      privateKey,
 		"public-key":       publicKey,
@@ -126,7 +126,7 @@ func (c *GroupGenerateEgressKey) Execute(ct *commands.Context) (repl models.Repl
 		"public-key-file":  publicKeyFile,
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	if ct.User.IsOwnerOfGroup(ct.FormattedArguments["group"]) {
 		str, _, errPK := ct.Group.DisplayPubKeys("egress")

--- a/cmd/groupInfo.go
+++ b/cmd/groupInfo.go
@@ -38,7 +38,7 @@ func (c *GroupInfo) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupInfo) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupInfo) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	fmt.Printf("Here are the info of group %s:\n", ct.Group.Name)
 

--- a/cmd/groupList.go
+++ b/cmd/groupList.go
@@ -39,7 +39,7 @@ func (c *GroupList) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupList) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupList) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	var groups map[string]*models.Group
 

--- a/cmd/groupListAccesses.go
+++ b/cmd/groupListAccesses.go
@@ -38,7 +38,7 @@ func (c *GroupListAccesses) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *GroupListAccesses) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *GroupListAccesses) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	accesses, err := ct.Group.GetAccesses()
 	if err != nil {

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -43,7 +43,7 @@ func (c *Help) Checks(ct *commands.Context) error {
 // help of the command named by the trailing words ("help self accesses
 // list"). Unknown names fall back to the root help rather than failing — help
 // must never refuse to help.
-func (c *Help) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Help) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	root := commands.BuildRootCommand(ct.Log, ct.User)
 	root.SetOut(os.Stdout)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -37,7 +37,7 @@ func (c *Info) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *Info) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Info) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	users, err := models.GetAllSBUsers()
 	if err != nil {

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -53,7 +54,7 @@ func (c *Interactive) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *Interactive) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Interactive) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	c.Context = ct
 
@@ -82,12 +83,15 @@ func (c *Interactive) Execute(ct *commands.Context) (repl models.ReplicationData
 
 		err = cmd.Wait()
 		if err != nil {
-			var ok bool
-			cmdError, ok = err.(*exec.ExitError)
+			exitErr, ok := err.(*exec.ExitError)
 			if !ok {
 				return
 			}
+			// The wrapped mosh-server exited unsuccessfully. That is the
+			// session's outcome, not an sb failure: report it as the remote
+			// exit so main can propagate the exit code.
 			err = nil
+			res.RemoteExit = &commands.ExitError{Code: exitErr.ExitCode(), Err: exitErr}
 		}
 
 		return
@@ -177,7 +181,9 @@ func (c *Interactive) promptExecutor(command string) {
 
 	err = root.Execute()
 	err = commands.WithCommandSuggestion(err, commandLine)
-	if err != nil && err != types.ErrMissingArguments {
+	// errors.Is, not ==: the dispatch layers may wrap the sentinel, which a
+	// plain comparison would miss.
+	if err != nil && !errors.Is(err, types.ErrMissingArguments) {
 		fmt.Printf("Error while executing command: %s\n", err)
 	}
 	log.SessionEndDate = time.Now()

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -52,7 +52,7 @@ func (c *Restore) Checks(ct *commands.Context) (err error) {
 	return
 }
 
-func (c *Restore) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Restore) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	binFilepath := ct.FormattedArguments["file"]
 	tgzFilepath := strings.Replace(ct.FormattedArguments["file"], ".bin", ".tar.gz", 1)

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -96,7 +96,7 @@ func (c *Scp) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *Scp) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Scp) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	// We have three cases:
 	//   - user calls scp with no arguments, we need to display the help
@@ -171,12 +171,15 @@ func (c *Scp) Execute(ct *commands.Context) (repl models.ReplicationData, cmdErr
 
 	err = cmd.Wait()
 	if err != nil {
-		var ok bool
-		cmdError, ok = err.(*exec.ExitError)
+		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
 			return
 		}
+		// The egress transfer process exited unsuccessfully. That is the
+		// distant side's outcome, not an sb failure: report it as the remote
+		// exit so main can propagate the exit code.
 		err = nil
+		res.RemoteExit = &commands.ExitError{Code: exitErr.ExitCode(), Err: exitErr}
 	}
 
 	// If the host key changed, point the user at the forget command (gated on trust).

--- a/cmd/selfAddAccess.go
+++ b/cmd/selfAddAccess.go
@@ -60,9 +60,9 @@ func (c *SelfAddAccess) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfAddAccess) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfAddAccess) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account": ct.User.User.Username,
 		"host":    ct.FormattedArguments["host"],
 		"user":    ct.FormattedArguments["user"],
@@ -71,7 +71,7 @@ func (c *SelfAddAccess) Execute(ct *commands.Context) (repl models.ReplicationDa
 		"comment": fmt.Sprintf("Access granted by %s on %s", ct.User.User.Username, time.Now().Format(time.RFC3339)),
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/selfAddIngressKey.go
+++ b/cmd/selfAddIngressKey.go
@@ -40,7 +40,7 @@ func (c *SelfAddIngressKey) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfAddIngressKey) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfAddIngressKey) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	str, keys, _ := ct.User.DisplayPubKeys("ingress")
 
@@ -75,12 +75,12 @@ func (c *SelfAddIngressKey) Execute(ct *commands.Context) (repl models.Replicati
 		}
 	}
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account":    ct.User.User.Username,
 		"public-key": pk.String(),
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	// We finally display the account's keys (output of selfListIngressKeys)
 	str, _, _ = ct.User.DisplayPubKeys("ingress")

--- a/cmd/selfDelAccess.go
+++ b/cmd/selfDelAccess.go
@@ -45,16 +45,16 @@ func (c *SelfDelAccess) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfDelAccess) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfDelAccess) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account": ct.User.User.Username,
 		"host":    ct.FormattedArguments["host"],
 		"user":    ct.FormattedArguments["user"],
 		"port":    ct.FormattedArguments["port"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/selfDelIngressKey.go
+++ b/cmd/selfDelIngressKey.go
@@ -43,7 +43,7 @@ func (c *SelfDelIngressKey) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfDelIngressKey) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfDelIngressKey) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	str, keys, err := ct.User.DisplayPubKeys("ingress")
 	if err != nil {
@@ -87,12 +87,12 @@ func (c *SelfDelIngressKey) Execute(ct *commands.Context) (repl models.Replicati
 		}
 	}
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account":    ct.User.User.Username,
 		"public-key": publicKey,
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	// We finally display the account's keys (output of selfListIngressKeys)
 	str, _, _ = ct.User.DisplayPubKeys("ingress")

--- a/cmd/selfDisableTOTP.go
+++ b/cmd/selfDisableTOTP.go
@@ -40,13 +40,13 @@ func (c *SelfDisableTOTP) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfDisableTOTP) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfDisableTOTP) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account": ct.User.User.Username,
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 
 	return
 }

--- a/cmd/selfEnableTOTP.go
+++ b/cmd/selfEnableTOTP.go
@@ -47,7 +47,7 @@ func (c *SelfEnableTOTP) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfEnableTOTP) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfEnableTOTP) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	green := color.New(color.FgGreen).SprintFunc()
 
@@ -108,13 +108,13 @@ func (c *SelfEnableTOTP) Execute(ct *commands.Context) (repl models.ReplicationD
 		return
 	}
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account":      ct.User.User.Username,
 		"secret":       key.Secret(),
 		"random-codes": strings.Join(randomCodes, ";"),
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 	if err != nil {
 		return
 	}

--- a/cmd/selfForgetHostkey.go
+++ b/cmd/selfForgetHostkey.go
@@ -37,14 +37,14 @@ func (c *SelfForgetHostkey) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfForgetHostkey) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfForgetHostkey) Execute(ct *commands.Context) (res commands.Result, err error) {
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account": ct.User.User.Username,
 		"hostkey": ct.FormattedArguments["hostkey"],
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 	if err != nil {
 		return
 	}

--- a/cmd/selfGenerateEgressKey.go
+++ b/cmd/selfGenerateEgressKey.go
@@ -74,7 +74,7 @@ func (c *SelfGenerateEgressKey) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfGenerateEgressKey) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfGenerateEgressKey) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	passphrase, ok := ct.FormattedArguments["encrypted"]
 	if ok {
@@ -112,7 +112,7 @@ func (c *SelfGenerateEgressKey) Execute(ct *commands.Context) (repl models.Repli
 		return
 	}
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"files-owner":      filesOwner,
 		"private-key":      privateKey,
 		"public-key":       publicKey,
@@ -120,7 +120,7 @@ func (c *SelfGenerateEgressKey) Execute(ct *commands.Context) (repl models.Repli
 		"public-key-file":  publicKeyFile,
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 	if err != nil {
 		return
 	}

--- a/cmd/selfGenerateTOTPCodes.go
+++ b/cmd/selfGenerateTOTPCodes.go
@@ -51,7 +51,7 @@ func (c *SelfGenerateTOTPCodes) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfGenerateTOTPCodes) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfGenerateTOTPCodes) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	// Re-read the current secret so the regenerated codes stay bound to it. Fail
 	// closed if it cannot be read rather than replicating an empty secret.
@@ -69,13 +69,13 @@ func (c *SelfGenerateTOTPCodes) Execute(ct *commands.Context) (repl models.Repli
 		return
 	}
 
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"account":      ct.User.User.Username,
 		"secret":       currentSecret,
 		"random-codes": strings.Join(random, ";"),
 	}
 
-	err = c.Replicate(repl)
+	err = c.Replicate(res.Repl)
 	if err != nil {
 		return
 	}

--- a/cmd/selfGetSessionAsGif.go
+++ b/cmd/selfGetSessionAsGif.go
@@ -61,7 +61,7 @@ func (c *SelfGetSessionAsGif) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfGetSessionAsGif) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfGetSessionAsGif) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	filename := fmt.Sprintf("%s.ttyrec", ct.FormattedArguments["session-id"])
 	localFilepath := fmt.Sprintf("%s/%s", ct.User.GetTtyrecDirectory(), filename)

--- a/cmd/selfListAccesses.go
+++ b/cmd/selfListAccesses.go
@@ -34,7 +34,7 @@ func (c *SelfListAccesses) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfListAccesses) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfListAccesses) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	accesses, err := ct.User.GetAccesses()
 	if err != nil {

--- a/cmd/selfListEgressKeys.go
+++ b/cmd/selfListEgressKeys.go
@@ -33,7 +33,7 @@ func (c *SelfListEgressKeys) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfListEgressKeys) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfListEgressKeys) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	str, _, err := ct.User.DisplayPubKeys("egress")
 	if err != nil {

--- a/cmd/selfListIngressKeys.go
+++ b/cmd/selfListIngressKeys.go
@@ -33,7 +33,7 @@ func (c *SelfListIngressKeys) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfListIngressKeys) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfListIngressKeys) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	str, _, err := ct.User.DisplayPubKeys("ingress")
 	if err != nil {

--- a/cmd/selfListSessions.go
+++ b/cmd/selfListSessions.go
@@ -34,7 +34,7 @@ func (c *SelfListSessions) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfListSessions) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfListSessions) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	lastSessions, err := ct.User.GetLastSSHSessions(20)
 	if err != nil {

--- a/cmd/selfPlaySession.go
+++ b/cmd/selfPlaySession.go
@@ -43,7 +43,7 @@ func (c *SelfPlaySession) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *SelfPlaySession) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *SelfPlaySession) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	filename := fmt.Sprintf("%s.ttyrec", ct.FormattedArguments["session-id"])
 	localFilepath := fmt.Sprintf("%s/%s", ct.User.GetTtyrecDirectory(), filename)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -46,7 +46,7 @@ func (c *Setup) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *Setup) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Setup) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	log.Printf("[SETUP     ] Gonna setup sb on this host")
 

--- a/cmd/ttyrec.go
+++ b/cmd/ttyrec.go
@@ -76,7 +76,7 @@ func (c *Ttyrec) Checks(ct *commands.Context) error {
 }
 
 // Execute executes the command
-func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmdError error, err error) {
+func (c *Ttyrec) Execute(ct *commands.Context) (res commands.Result, err error) {
 
 	c.displayHeader(ct.User.User.Username)
 
@@ -95,7 +95,7 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 	}
 
 	// We will provide the ttyrec record path as a replication data for the post exec step
-	repl = models.ReplicationData{
+	res.Repl = models.ReplicationData{
 		"ttyrec-record-path": fmt.Sprintf("%s/%s.ttyrec", ct.User.GetTtyrecDirectory(), ct.Log.UniqID),
 	}
 
@@ -154,7 +154,7 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 	// io.Discard is typed io.Writer, so rec stays an io.Writer that the
 	// successful branch can reassign to the recording encoder.
 	rec := io.Discard
-	if f, ferr := os.Create(repl["ttyrec-record-path"]); ferr != nil {
+	if f, ferr := os.Create(res.Repl["ttyrec-record-path"]); ferr != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: unable to open ttyrec file: %s\n", ferr)
 	} else {
 		defer f.Close()
@@ -205,20 +205,27 @@ func (c *Ttyrec) Execute(ct *commands.Context) (repl models.ReplicationData, cmd
 	err = cmd.Wait()
 	if err != nil {
 
-		var ok bool
-		cmdError, ok = err.(*exec.ExitError)
+		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
 			err = fmt.Errorf("unable to wait for command: %w", err)
 			return
 		}
 
+		// The egress ssh process exited unsuccessfully (non-zero remote exit
+		// or killed by a signal). That is the distant command's outcome, not
+		// an sb failure: report it as the remote exit so main can propagate
+		// the exit code.
 		err = nil
+		res.RemoteExit = &commands.ExitError{Code: exitErr.ExitCode(), Err: exitErr}
 	}
 
 	fmt.Printf("<< Exited shell: %s\n", cmd.ProcessState.String())
 
-	if cmd.ProcessState.ExitCode() > 0 {
-		cmdError = fmt.Errorf("failed to execute command on distant host: %w", cmdError)
+	// A positive exit code means the remote command itself failed; keep the
+	// historical message for it. A signal death (ExitCode -1) keeps the bare
+	// exec wording ("signal: ...") exactly as before.
+	if res.RemoteExit != nil && res.RemoteExit.Code > 0 {
+		res.RemoteExit.Err = fmt.Errorf("failed to execute command on distant host: %w", res.RemoteExit.Err)
 	}
 
 	// If the connection was refused because the distant host's key changed, give

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -162,6 +162,33 @@ Available commands:
   - self totp enable                   : enable TOTP on the account
 ```
 
+## Exit codes
+
+`sb` behaves like plain `ssh` for scripting: when you run a command on a distant host
+through the bastion, the distant command's exit code becomes `sb`'s own exit code, so
+`$?` on your side reflects what actually happened on the host. The same applies to SCP
+transfers and mosh sessions.
+
+```console
+t1000@skynet:~# sb root@host.domain.tld -- true ; echo $?
+...
+0
+t1000@skynet:~# sb root@host.domain.tld -- exit 3 ; echo $?
+...
+Error while executing command: failed to execute command on distant host: exit status 3
+3
+```
+
+The full mapping:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success (including a remote command that exited `0`). |
+| `1` | An `sb` error: refused authorization, unknown command, internal failure — or a remote process killed by a signal, which a process exit code cannot express. |
+| `2` | Missing arguments. |
+| `126` | The command is disabled on this instance (e.g. `daemon` invoked while replication and TTYRec offloading are both disabled). |
+| _other_ | The distant command's own exit code, propagated as-is. |
+
 ## Egress host-key verification
 
 When `sb` connects you to a distant host (interactive sessions and SCP alike), it pins the

--- a/internal/commands/cobratree.go
+++ b/internal/commands/cobratree.go
@@ -179,7 +179,7 @@ func findOrCreateChild(parent *cobra.Command, word string) *cobra.Command {
 
 // newLeafCommand builds the executable cobra command for a spec and wires the
 // adapter between cobra's single-error RunE world and the sb Command
-// interface (Checks + Execute returning replication data and two errors).
+// interface (Checks + Execute returning a Result and an internal error).
 //
 // The execution pipeline mirrors the historical BuildSBCommand /
 // BuildAndExecuteSBCommand pair exactly:
@@ -284,13 +284,13 @@ func newLeafCommand(spec *CommandSpec, log *models.Log, user *models.User, deps 
 			return err
 		}
 
-		replicationData, cmdErr, err := inst.Execute(ct)
+		res, err := inst.Execute(ct)
 		if err != nil {
 			return err
 		}
 
 		if deps.replicationOn() && IsReplicableCommand(spec.Name) {
-			repl, err := models.NewReplicationEntry(spec.Name, replicationData)
+			repl, err := models.NewReplicationEntry(spec.Name, res.Repl)
 			if err != nil {
 				return err
 			}
@@ -299,9 +299,15 @@ func newLeafCommand(spec *CommandSpec, log *models.Log, user *models.User, deps 
 			}
 		}
 
-		// cmdErr is the distant command's exit error (not an sb failure); it
-		// propagates so the caller can map it to the process exit code.
-		return cmdErr
+		// A remote exit is the distant command's failure, not an sb failure;
+		// it propagates as a typed *ExitError so the top-level caller can map
+		// it to the process exit code with errors.As. The nil check matters:
+		// returning a nil *ExitError directly would yield a non-nil error
+		// interface value.
+		if res.RemoteExit != nil {
+			return res.RemoteExit
+		}
+		return nil
 	}
 
 	return leaf

--- a/internal/commands/cobratree_test.go
+++ b/internal/commands/cobratree_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	osuser "os/user"
 	"testing"
@@ -17,9 +18,8 @@ import (
 // adapter drives it.
 type fakeCommand struct {
 	checksErr error
-	execRepl  models.ReplicationData
-	execCmd   error // remote/command exit error returned by Execute
-	execErr   error // internal sb error returned by Execute
+	execRes   Result // Result returned by Execute (replication data + remote exit)
+	execErr   error  // internal sb error returned by Execute
 
 	checksCalled bool
 	execCalled   bool
@@ -32,10 +32,10 @@ func (f *fakeCommand) Checks(ct *Context) error {
 	return f.checksErr
 }
 
-func (f *fakeCommand) Execute(ct *Context) (models.ReplicationData, error, error) {
+func (f *fakeCommand) Execute(ct *Context) (Result, error) {
 	f.execCalled = true
 	f.gotCt = ct
-	return f.execRepl, f.execCmd, f.execErr
+	return f.execRes, f.execErr
 }
 
 func (f *fakeCommand) PostExecute(repl models.ReplicationData) error { return nil }
@@ -215,8 +215,8 @@ func TestAdapterArgumentHandling(t *testing.T) {
 
 // TestAdapterPipeline asserts the ordering and error-propagation contract of
 // the PersistentPreRunE/RunE pair: authorization gates Checks, Checks gates
-// Execute, the outbox handle is acquired before Execute, and the two Execute
-// errors keep their distinct roles.
+// Execute, the outbox handle is acquired before Execute, and the internal
+// error and the Result's remote exit keep their distinct roles.
 func TestAdapterPipeline(t *testing.T) {
 
 	registryWith := func(fake *fakeCommand, rights models.Right) *Registry {
@@ -268,16 +268,37 @@ func TestAdapterPipeline(t *testing.T) {
 		require.False(t, fake.execCalled, "an action whose outbox entry cannot be persisted must not run")
 	})
 
-	t.Run("internal error wins over the remote exit error", func(t *testing.T) {
-		fake := &fakeCommand{execErr: fmt.Errorf("internal"), execCmd: fmt.Errorf("remote exit 1")}
+	t.Run("internal error wins over the remote exit", func(t *testing.T) {
+		fake := &fakeCommand{
+			execErr: fmt.Errorf("internal"),
+			execRes: Result{RemoteExit: &ExitError{Code: 1, Err: fmt.Errorf("remote exit 1")}},
+		}
 		_, err := execute(registryWith(fake, models.Public), []string{"thing", "do"}, hermeticDeps()...)
 		require.EqualError(t, err, "internal")
+		var exitErr *ExitError
+		require.False(t, errors.As(err, &exitErr), "an internal failure must not surface as a remote exit")
 	})
 
-	t.Run("remote exit error propagates when there is no internal error", func(t *testing.T) {
-		fake := &fakeCommand{execCmd: fmt.Errorf("remote exit 1")}
+	t.Run("remote exit propagates as a typed *ExitError when there is no internal error", func(t *testing.T) {
+		fake := &fakeCommand{
+			execRes: Result{RemoteExit: &ExitError{Code: 3, Err: fmt.Errorf("remote exit 3")}},
+		}
 		_, err := execute(registryWith(fake, models.Public), []string{"thing", "do"}, hermeticDeps()...)
-		require.EqualError(t, err, "remote exit 1")
+		require.EqualError(t, err, "remote exit 3")
+		// The typed exit must survive the adapter so the top-level caller can
+		// recover the distant command's exit code with errors.As.
+		var exitErr *ExitError
+		require.ErrorAs(t, err, &exitErr)
+		require.Equal(t, 3, exitErr.Code)
+	})
+
+	t.Run("a successful execution returns a nil error, not a typed nil", func(t *testing.T) {
+		// The adapter must not return Result.RemoteExit unconditionally: a nil
+		// *ExitError stored in the error interface would be non-nil and turn
+		// every success into a failure.
+		fake := &fakeCommand{}
+		_, err := execute(registryWith(fake, models.Public), []string{"thing", "do"}, hermeticDeps()...)
+		require.NoError(t, err)
 	})
 
 	t.Run("group argument resolves before authorization", func(t *testing.T) {
@@ -318,7 +339,7 @@ func TestAdapterReplicationOutbox(t *testing.T) {
 	db, err := models.GetReplicationGormDB(":memory:")
 	require.NoError(t, err)
 
-	fake := &fakeCommand{execRepl: models.ReplicationData{"account": "alice"}}
+	fake := &fakeCommand{execRes: Result{Repl: models.ReplicationData{"account": "alice"}}}
 	r := NewRegistry()
 	spec := specStub("thing do", []string{"thingDo"}, false)
 	spec.New = func() Command { return fake }

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -52,7 +52,7 @@ func BuildAndExecuteSBCommand(log *models.Log, user *models.User, args ...string
 	}
 
 	// Call the execute method
-	replicationData, cmdErr, err := bc.Execute(ct)
+	res, err := bc.Execute(ct)
 	if err != nil {
 		return
 	}
@@ -64,7 +64,7 @@ func BuildAndExecuteSBCommand(log *models.Log, user *models.User, args ...string
 
 		var repl *models.Replication
 
-		repl, err = models.NewReplicationEntry(args[0], replicationData)
+		repl, err = models.NewReplicationEntry(args[0], res.Repl)
 		if err != nil {
 			return
 		}
@@ -76,7 +76,14 @@ func BuildAndExecuteSBCommand(log *models.Log, user *models.User, args ...string
 
 	}
 
-	return cmdErr
+	// A remote exit is the distant command's failure, not an sb failure; it
+	// propagates as a typed *ExitError so the top-level caller can map it to
+	// the process exit code with errors.As. The nil check matters: assigning
+	// a nil *ExitError to err would yield a non-nil error interface value.
+	if res.RemoteExit != nil {
+		err = res.RemoteExit
+	}
+	return
 }
 
 // buildArgumentsList constructs a map[string]string from the arguments lists.

--- a/internal/commands/types.go
+++ b/internal/commands/types.go
@@ -1,15 +1,77 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/golgeek/sb/internal/models"
 )
 
-// Command descibes the required functions of a sb command interface
+// Command describes the required functions of a sb command interface.
+//
+// The lifecycle of a command on the CLI dispatch path is Checks → Execute;
+// PostExecute and Replicate run later on the daemon's replication paths, fed
+// with the ReplicationData that Execute produced (Result.Repl, persisted in
+// the replication outbox).
 type Command interface {
 	Checks(ct *Context) error
-	Execute(ct *Context) (models.ReplicationData, error, error)
+	Execute(ct *Context) (Result, error)
 	PostExecute(repl models.ReplicationData) error
 	Replicate(repl models.ReplicationData) error
+}
+
+// Result is the outcome of a successful command execution.
+//
+// It separates the two things a command can produce besides an internal sb
+// error: the data to persist in the replication outbox (Repl) and the exit
+// status of a distant or wrapped process (RemoteExit). Execute therefore
+// returns (Result, error) where the single error always means "sb itself
+// failed"; a remote command failing is not an sb failure and travels in
+// Result instead. This replaces the historical (ReplicationData, cmdError,
+// err) triple whose two error returns were routinely confused.
+type Result struct {
+	// Repl is the data persisted in the replication outbox after a
+	// successful execution and later fed to PostExecute/Replicate on the
+	// daemon paths. Nil when the command has nothing to replicate.
+	Repl models.ReplicationData
+
+	// RemoteExit is non-nil only when the distant or wrapped process the
+	// command drove (egress ssh for ttyrec/scp, mosh-server for interactive)
+	// terminated unsuccessfully. The dispatch adapters propagate it as the
+	// execution error so main can map it to the bastion's process exit code.
+	RemoteExit *ExitError
+}
+
+// ExitError reports the unsuccessful termination of the distant or wrapped
+// process a command drove. It is the typed form of the historical "cmdError"
+// return: callers detect it with errors.As and map Code to the bastion's own
+// process exit code, so a script driving `ssh bastion host -- cmd` observes
+// the distant command's real exit status.
+type ExitError struct {
+	// Code is the process's exit code. It is -1 when the process was
+	// terminated by a signal rather than exiting (the exec.ExitError
+	// convention); consumers map non-positive codes to a generic failure.
+	Code int
+
+	// Err is the underlying cause — typically the *exec.ExitError from
+	// Wait, possibly wrapped with command-specific context. It must be
+	// non-nil; Error and Unwrap delegate to it.
+	Err error
+}
+
+// Error returns the underlying cause's message, so user-visible output keeps
+// the exact wording commands historically produced (e.g. "exit status 3" or
+// "failed to execute command on distant host: exit status 3").
+func (e *ExitError) Error() string {
+	if e.Err == nil {
+		// Defensive: a well-formed ExitError always carries its cause.
+		return fmt.Sprintf("exit status %d", e.Code)
+	}
+	return e.Err.Error()
+}
+
+// Unwrap exposes the underlying cause to errors.Is/errors.As chains.
+func (e *ExitError) Unwrap() error {
+	return e.Err
 }
 
 type Context struct {

--- a/internal/commands/types_test.go
+++ b/internal/commands/types_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExitErrorMessage asserts ExitError preserves the user-visible wording
+// of the historical untyped errors: the message is the underlying cause's
+// message, with a defensive fallback when the cause is missing.
+func TestExitErrorMessage(t *testing.T) {
+
+	t.Run("message delegates to the underlying cause", func(t *testing.T) {
+		e := &ExitError{Code: 3, Err: fmt.Errorf("exit status 3")}
+		require.EqualError(t, e, "exit status 3")
+	})
+
+	t.Run("wrapped cause keeps the command-specific context", func(t *testing.T) {
+		// ttyrec wraps the egress ssh failure with its historical message;
+		// the typed error must surface it unchanged.
+		cause := fmt.Errorf("failed to execute command on distant host: %w", fmt.Errorf("exit status 3"))
+		e := &ExitError{Code: 3, Err: cause}
+		require.EqualError(t, e, "failed to execute command on distant host: exit status 3")
+	})
+
+	t.Run("missing cause falls back to the exit code", func(t *testing.T) {
+		e := &ExitError{Code: 7}
+		require.EqualError(t, e, "exit status 7")
+	})
+}
+
+// TestExitErrorUnwrap asserts the typed error participates in errors.Is /
+// errors.As chains: callers find the *ExitError through any wrapping, and the
+// underlying cause stays reachable through the ExitError itself.
+func TestExitErrorUnwrap(t *testing.T) {
+
+	cause := fmt.Errorf("exit status 3")
+	var err error = &ExitError{Code: 3, Err: cause}
+
+	require.ErrorIs(t, err, cause, "the underlying cause must stay reachable via Unwrap")
+
+	// Wrapping the typed error (as a dispatch layer might) must not hide it.
+	wrapped := fmt.Errorf("session ended: %w", err)
+	var exitErr *ExitError
+	require.True(t, errors.As(wrapped, &exitErr))
+	require.Equal(t, 3, exitErr.Code)
+}

--- a/main.go
+++ b/main.go
@@ -195,19 +195,44 @@ func TerminateSession(log *models.Log, err error) {
 		fmt.Fprintf(os.Stderr, "WARNING: unable to persist audit log: %s\n", saveErr)
 	}
 
-	var statusCode int
-	switch err {
-	case nil:
-		statusCode = 0
-	case types.ErrCommandDisabled:
-		statusCode = 126
-		fmt.Printf("This command is disabled\n")
-	case types.ErrMissingArguments:
-		statusCode = 2
-	default:
-		statusCode = 1
-		fmt.Printf("Error while executing command: %s\n", err)
+	statusCode, message := sessionExitStatus(err)
+	if message != "" {
+		fmt.Println(message)
 	}
 
 	os.Exit(statusCode)
+}
+
+// sessionExitStatus maps the dispatch result to the bastion's process exit
+// code and the message to print, kept separate from TerminateSession so the
+// mapping is unit-testable (TerminateSession calls os.Exit).
+//
+// The sentinel checks use errors.Is — the dispatch layers may wrap a sentinel
+// (e.g. with a "did you mean" suggestion), which the historical == comparison
+// silently missed. A *commands.ExitError carries the distant command's real
+// exit code: it becomes the bastion's own exit code (like plain ssh), so
+// scripts driving `ssh bastion host -- cmd` observe the remote status rather
+// than a flat 1. Non-positive codes (the exec convention for a signal death)
+// map to the generic failure code 1, which a process exit code cannot
+// express more faithfully.
+func sessionExitStatus(err error) (statusCode int, message string) {
+
+	var remoteExit *commands.ExitError
+
+	switch {
+	case err == nil:
+		return 0, ""
+	case errors.Is(err, types.ErrCommandDisabled):
+		return 126, "This command is disabled"
+	case errors.Is(err, types.ErrMissingArguments):
+		return 2, ""
+	case errors.As(err, &remoteExit):
+		statusCode = remoteExit.Code
+		if statusCode <= 0 {
+			statusCode = 1
+		}
+		return statusCode, fmt.Sprintf("Error while executing command: %s", err)
+	default:
+		return 1, fmt.Sprintf("Error while executing command: %s", err)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golgeek/sb/internal/commands"
+	"github.com/golgeek/sb/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionExitStatus pins the dispatch-result → process-exit-code mapping:
+// sentinels keep their historical codes (and now match through wrapping), a
+// remote command's exit code propagates as the bastion's own exit code, and
+// everything else stays a generic failure.
+func TestSessionExitStatus(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		err         error
+		wantCode    int
+		wantMessage string
+	}{
+		{
+			name:     "success",
+			err:      nil,
+			wantCode: 0,
+		},
+		{
+			name:        "disabled command",
+			err:         types.ErrCommandDisabled,
+			wantCode:    126,
+			wantMessage: "This command is disabled",
+		},
+		{
+			name: "wrapped disabled command still matches",
+			// The historical == comparison missed a wrapped sentinel; the
+			// errors.Is mapping must not.
+			err:         fmt.Errorf("dispatch: %w", types.ErrCommandDisabled),
+			wantCode:    126,
+			wantMessage: "This command is disabled",
+		},
+		{
+			name:     "missing arguments",
+			err:      types.ErrMissingArguments,
+			wantCode: 2,
+		},
+		{
+			name:     "wrapped missing arguments still matches",
+			err:      fmt.Errorf("dispatch: %w", types.ErrMissingArguments),
+			wantCode: 2,
+		},
+		{
+			name: "remote exit code propagates",
+			err: &commands.ExitError{
+				Code: 3,
+				Err:  fmt.Errorf("failed to execute command on distant host: exit status 3"),
+			},
+			wantCode:    3,
+			wantMessage: "Error while executing command: failed to execute command on distant host: exit status 3",
+		},
+		{
+			name: "wrapped remote exit still propagates",
+			err: fmt.Errorf("session: %w", &commands.ExitError{
+				Code: 5,
+				Err:  fmt.Errorf("exit status 5"),
+			}),
+			wantCode:    5,
+			wantMessage: "Error while executing command: session: exit status 5",
+		},
+		{
+			name: "signal death maps to the generic failure code",
+			// exec reports -1 when the process was killed by a signal; a
+			// process exit code cannot express that, so it maps to 1.
+			err:         &commands.ExitError{Code: -1, Err: fmt.Errorf("signal: killed")},
+			wantCode:    1,
+			wantMessage: "Error while executing command: signal: killed",
+		},
+		{
+			name:        "internal error stays a generic failure",
+			err:         fmt.Errorf("unable to open database"),
+			wantCode:    1,
+			wantMessage: "Error while executing command: unable to open database",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, message := sessionExitStatus(tt.err)
+			require.Equal(t, tt.wantCode, code)
+			require.Equal(t, tt.wantMessage, message)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`Command.Execute` now returns `(commands.Result, error)` instead of the historical `(models.ReplicationData, error, error)` triple. `Result` carries the replication outbox data (`Repl`) and a typed `*commands.ExitError` (`RemoteExit`) for the distant/wrapped process's failure; the single `error` always means sb itself failed. As a consequence, the distant command's exit code now propagates as the bastion's own process exit code, like plain `ssh`.

## Previous behavior

`Execute` returned two same-typed errors: the first was the remote command's exit error, the second an internal sb error. Only three of the 42 commands (`ttyrec`, `scp`, `interactive`'s mosh path) ever produced the remote one; every other command carried dead boilerplate.

## Why it was a problem

- The two error returns were routinely confused at call sites — nothing but position distinguished them.
- The dispatch layers erased the remote exit status: any failure on the distant host surfaced as a flat process exit code of `1`, so scripts driving `ssh bastion host -- cmd` could not observe the real outcome.
- `main`'s sentinel mapping compared errors with `==`, so a wrapped sentinel (e.g. one enriched with a "did you mean" suggestion) silently fell through to the generic branch.

## What changed

- `internal/commands`: new `Result` and `ExitError` types (with `Error`/`Unwrap`, so `errors.As`/`errors.Is` work through wrapping); `Command.Execute` becomes `(Result, error)`; all 42 commands converted (mechanical for 39 of them).
- Both dispatch adapters (the cobra `RunE` adapter and the trusted flat path) persist the outbox entry from `Result.Repl` and propagate a non-nil `RemoteExit` as the execution error, guarding against the typed-nil-in-interface pitfall.
- `main`: the exit-code mapping is extracted into a testable `sessionExitStatus` function — sentinels matched with `errors.Is` (`ErrCommandDisabled` → 126, `ErrMissingArguments` → 2), the typed remote exit recovered with `errors.As` and **propagated as the process exit code** (signal deaths, reported as `-1`, map to the generic `1`). The interactive REPL's `ErrMissingArguments` comparison received the same `errors.Is` fix.
- User-visible error messages are unchanged, including ttyrec's "failed to execute command on distant host" wrapping.
- The exit-code contract is documented in `docs/usage.md`.

The exit-code propagation is the one deliberate behavior change: a failing remote command previously always exited `1`; it now exits with the remote command's real code.

## How it's tested

- New unit tests for `ExitError` (message wording stability, `Unwrap`, `errors.As` through wrapping).
- Adapter tests assert the typed remote exit propagates with its code, internal errors take precedence over a remote exit, and a successful execution returns a `nil` error rather than a typed nil.
- A table test pins the full `sessionExitStatus` mapping, including wrapped sentinels and the signal-death case.
- `go build ./...`, `go test ./...` and `golangci-lint run` are green.
- The demo-stack e2e suite passes end to end; exit-code propagation additionally verified against the live demo bastion (remote `exit 3`/`exit 42` surface as sb exit 3/42, success as 0).

## Test plan

- [ ] `go build ./... && go test ./...`
- [ ] `golangci-lint run`
- [ ] `tests/e2e-local.sh` (first command may flake on the known TCP-probe race; re-run)
- [ ] Against the demo stack: `ssh -p 22001 t800@127.0.0.1 -A -tt -- "root@examplevm -- exit 3"; echo $?` prints `3`