### PR TITLE
models: parse IPv6 literals in user-typed access targets

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,8 +111,10 @@ Host supported formats:
   - full formats:
     - user@example.com:22
     - user@127.0.0.1:22
+    - user@[2001:db8::1]:22 (IPv6 with a port requires brackets)
   - short formats*:
     - user@example.com : port will be retrieved from granted access
+    - user@2001:db8::1 : port will be retrieved from granted access
     - example.com:22   : user will be retrieved from granted access
     - example.com      : port and user will be retrieved from granted access
   - alias*:

--- a/internal/commands/cobratree.go
+++ b/internal/commands/cobratree.go
@@ -118,8 +118,10 @@ Host supported formats:
   - full formats:
     - user@example.com:22
     - user@127.0.0.1:22
+    - user@[2001:db8::1]:22 (IPv6 with a port requires brackets)
   - short formats*:
     - user@example.com : port will be retrieved from granted access
+    - user@2001:db8::1 : port will be retrieved from granted access
     - example.com:22   : user will be retrieved from granted access
     - example.com      : port and user will be retrieved from granted access
   - alias*:

--- a/internal/models/access.go
+++ b/internal/models/access.go
@@ -318,38 +318,81 @@ func isIPv4(ip string) bool {
 	return strings.Count(ip, ":") < 2
 }
 
+// splitUserInput parses a user-typed access target of the form
+// [user@]host[:port], where host may be a hostname, an access alias, an IPv4
+// address, or an IPv6 address. IPv6 literals follow the standard bracket
+// convention: combining an IPv6 address with a port requires brackets
+// ("user@[2001:db8::1]:22" — net.SplitHostPort semantics), while a bare,
+// unbracketed IPv6 address (two or more colons) is accepted as a host
+// without a port. Brackets without a port ("user@[::1]") are also accepted.
+//
+// When strictHostCheck is set, the user@ part is mandatory and its absence is
+// an error; otherwise an input without @ is treated as a host or alias. port
+// is 0 when the input does not carry one. err is non-nil for a non-numeric
+// port, an unclosed bracket, or a missing @ under strictHostCheck.
 func splitUserInput(userInput string, strictHostCheck bool) (user, host string, port int, err error) {
 
-	// We start by determining if we have a specified port
-	hostPortParts := strings.Split(userInput, ":")
-	if len(hostPortParts) > 1 {
-		portInt, errConv := strconv.Atoi(hostPortParts[1])
-		if errConv != nil {
-			err = fmt.Errorf("port is not a valid integer")
-			return
-		}
-		port = portInt
-	}
+	hostPort := userInput
 
-	// Then we concentrate on the host part (which could be an alias to a host, by the way)
-	userHostParts := strings.Split(hostPortParts[0], "@")
-
-	// No @ present in the user input, we consider input to be an alias of a host
-	if len(userHostParts) < 2 {
-
-		// Unless we have a strictHostCheck flag
-		if strictHostCheck {
-			err = fmt.Errorf("unable to parse access from user input %s: no @ separator found", userInput)
-			return
-		}
-
-		// We set the alias in the host field, and we won't have more info, so let's return
-		host = hostPortParts[0]
+	// Split off the user part first, so a user@ prefix can never be confused
+	// with the colons of an IPv6 literal in the host part.
+	if i := strings.Index(hostPort, "@"); i >= 0 {
+		user = hostPort[:i]
+		hostPort = hostPort[i+1:]
+	} else if strictHostCheck {
+		err = fmt.Errorf("unable to parse access from user input %s: no @ separator found", userInput)
 		return
 	}
 
-	user = userHostParts[0]
-	host = userHostParts[1]
+	switch {
+	case strings.HasPrefix(hostPort, "["):
 
-	return
+		// Bracketed host: "[addr]:port" or "[addr]" alone. net.SplitHostPort
+		// handles the former (and validates the bracket structure); a
+		// bracketed host without a port is unwrapped by hand since
+		// SplitHostPort treats a missing port as an error.
+		if h, p, splitErr := net.SplitHostPort(hostPort); splitErr == nil {
+			host = h
+			port, err = parsePort(p)
+			return
+		}
+		if strings.HasSuffix(hostPort, "]") {
+			host = strings.TrimPrefix(strings.TrimSuffix(hostPort, "]"), "[")
+			return
+		}
+		err = fmt.Errorf("unable to parse access from user input %s: unclosed bracket in host", userInput)
+		return
+
+	case strings.Count(hostPort, ":") >= 2:
+
+		// Two or more colons and no brackets: a bare IPv6 literal. It cannot
+		// carry a port (that requires the bracketed form above), so the whole
+		// token is the host.
+		host = hostPort
+		return
+
+	case strings.Contains(hostPort, ":"):
+
+		// Exactly one colon: the historical "host:port" form.
+		parts := strings.SplitN(hostPort, ":", 2)
+		host = parts[0]
+		port, err = parsePort(parts[1])
+		return
+
+	default:
+
+		// No port; the whole token is a hostname or an alias.
+		host = hostPort
+		return
+	}
+}
+
+// parsePort converts a user-typed port to an int, with the historical error
+// message on non-numeric input.
+func parsePort(p string) (port int, err error) {
+	port, errConv := strconv.Atoi(p)
+	if errConv != nil {
+		return 0, fmt.Errorf("port is not a valid integer")
+	}
+	return port, nil
 }

--- a/internal/models/access_test.go
+++ b/internal/models/access_test.go
@@ -303,6 +303,61 @@ func TestSplitUserInputStrict(t *testing.T) {
 				err: fmt.Errorf("port is not a valid integer"),
 			},
 		},
+		// IPv6: a port requires the standard bracketed form.
+		{
+			e: testSplitUserInputInputData{
+				access: "root@[2001:db8::1]:2222", strictHostCheck: true,
+			},
+			o: testSplitUserInputOutputData{
+				host: "2001:db8::1", user: "root", port: 2222,
+			},
+		},
+		// IPv6: brackets without a port are accepted too.
+		{
+			e: testSplitUserInputInputData{
+				access: "root@[::1]", strictHostCheck: true,
+			},
+			o: testSplitUserInputOutputData{
+				host: "::1", user: "root", port: 0,
+			},
+		},
+		// IPv6: a bare literal (no brackets) is a host without a port; its
+		// colons must not be parsed as a port separator.
+		{
+			e: testSplitUserInputInputData{
+				access: "root@::1", strictHostCheck: true,
+			},
+			o: testSplitUserInputOutputData{
+				host: "::1", user: "root", port: 0,
+			},
+		},
+		{
+			e: testSplitUserInputInputData{
+				access: "root@2001:db8::1", strictHostCheck: true,
+			},
+			o: testSplitUserInputOutputData{
+				host: "2001:db8::1", user: "root", port: 0,
+			},
+		},
+		// IPv6: the historical non-numeric-port error is preserved in the
+		// bracketed form.
+		{
+			e: testSplitUserInputInputData{
+				access: "root@[::1]:port", strictHostCheck: true,
+			},
+			o: testSplitUserInputOutputData{
+				err: fmt.Errorf("port is not a valid integer"),
+			},
+		},
+		// IPv6: an unclosed bracket is a parse error, not a silent guess.
+		{
+			e: testSplitUserInputInputData{
+				access: "root@[::1:22", strictHostCheck: true,
+			},
+			o: testSplitUserInputOutputData{
+				err: fmt.Errorf("unable to parse access from user input root@[::1:22: unclosed bracket in host"),
+			},
+		},
 	}
 
 	for _, testValue := range testValues {
@@ -363,6 +418,32 @@ func TestSplitUserInputAlias(t *testing.T) {
 			},
 			o: testSplitUserInputOutputData{
 				host: "test", user: "", port: 22,
+			},
+		},
+		// IPv6 without a user part: bracketed with a port, and bare literals
+		// of both short and full forms.
+		{
+			e: testSplitUserInputInputData{
+				access: "[::1]:22", strictHostCheck: false,
+			},
+			o: testSplitUserInputOutputData{
+				host: "::1", user: "", port: 22,
+			},
+		},
+		{
+			e: testSplitUserInputInputData{
+				access: "::1", strictHostCheck: false,
+			},
+			o: testSplitUserInputOutputData{
+				host: "::1", user: "", port: 0,
+			},
+		},
+		{
+			e: testSplitUserInputInputData{
+				access: "2001:0db8:85a3:0000:0000:8a2e:0370:7334", strictHostCheck: false,
+			},
+			o: testSplitUserInputOutputData{
+				host: "2001:0db8:85a3:0000:0000:8a2e:0370:7334", user: "", port: 0,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

`splitUserInput` — the parser behind every user-typed access target (`sb user@host:port`, `self access add`, SCP targets) — now understands IPv6 literals, using the standard bracket convention.

## Previous behavior

The parser split the whole input on `:` and treated the second segment as the port.

## Why it was a problem

Every IPv6 literal contains colons, so `user@::1` failed with "port is not a valid integer" and there was no syntax at all for an IPv6 host with a port. The parser was the only blocker: `BuildSBAccess` already handles IPv6 downstream (`net.ParseIP`, `/128` prefixes).

## What changed

`splitUserInput` was rewritten around `net.SplitHostPort` semantics:

- the `user@` part is split off first, so its separator can never be confused with the host's colons;
- `user@[2001:db8::1]:22` — bracketed IPv6 with a port (brackets required to combine the two);
- `user@[::1]` — bracketed without a port also accepted;
- `user@::1` / `::1` — a bare unbracketed literal (two or more colons) is a host without a port;
- `host:port` (single colon) keeps its historical behavior, error message included;
- an unclosed bracket is rejected explicitly rather than guessed at.

Hostname, IPv4, alias, and strict-check behavior is unchanged. The host-format help (cobra root help and `docs/usage.md`) now shows the IPv6 forms.

## How it's tested

The existing `splitUserInput` test tables pin the unchanged behavior; new entries cover bracketed-with-port, bracketed-without-port, bare short- and full-form literals, the non-numeric-port error in the bracketed form, and the unclosed-bracket error — with and without a user part. `go build ./...`, `go test ./...` and `golangci-lint run` are green on top of current main.

## Test plan

- [ ] `go test ./internal/models/`
- [ ] `sb root@[::1]:22` / `sb root@::1` parse (and fail on the access check, not the parser)