### PR TITLE
models: move the login-time TOTP outbox sync out of main

### DIFF
--- a/internal/models/replication.go
+++ b/internal/models/replication.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/golgeek/sb/internal/config"
@@ -42,6 +43,67 @@ func (r *Replication) Delete(db *gorm.DB) (err error) {
 func (r *Replication) Save(db *gorm.DB) (err error) {
 	// We insert or update our access
 	return db.Save(r).Error
+}
+
+// SyncTOTPState snapshots the user's current TOTP state (shared secret +
+// remaining emergency codes, read from their ~/.google_authenticator file)
+// into the replication outbox at dbPath, so peer instances converge on the
+// same state. It exists because emergency codes are consumed by
+// pam_google_authenticator during SSH authentication — before sb runs and
+// without any event sb could observe — so the only way to invalidate a used
+// code on the other instances is to re-publish the file's current content.
+// The front-end calls it on every invocation when replication is enabled;
+// when nothing changed, applying the snapshot on a peer is a no-op overwrite.
+//
+// The outbox action is "self totp emergency-codes generate" on purpose: peers
+// apply the snapshot through that command's existing Replicate handler, as if
+// the user had regenerated their codes to exactly the current set. The string
+// is part of the persisted replication name contract and must not change.
+//
+// Users without TOTP (no ~/.google_authenticator) are a successful no-op; the
+// outbox is not even opened for them. Every failure — unreadable/malformed
+// TOTP file, unavailable outbox database, entry encryption or persistence —
+// is returned as a non-nil error. The caller decides what a failure means;
+// the front-end deliberately treats it as best-effort (warn loudly, let the
+// session proceed: the snapshot retries on the user's next invocation, and
+// blocking on an outbox hiccup would lock every TOTP user out of the
+// bastion).
+func SyncTOTPState(user *User, dbPath string) (err error) {
+
+	totpEnabled, secret, totpEmergency, err := user.GetTOTP()
+	if err != nil {
+		return fmt.Errorf("unable to read TOTP state: %w", err)
+	}
+	if !totpEnabled {
+		return nil
+	}
+
+	db, err := GetReplicationGormDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("unable to open the replication outbox: %w", err)
+	}
+
+	// The process is short-lived, but closing the handle keeps the outbox
+	// file unlocked for the daemon. Best-effort: the entry is already
+	// persisted by then, so a close failure must not fail the sync.
+	if sqlDB, dbErr := db.DB(); dbErr == nil {
+		defer sqlDB.Close()
+	}
+
+	repl, err := NewReplicationEntry("self totp emergency-codes generate", ReplicationData{
+		"account":      user.User.Username,
+		"secret":       secret,
+		"random-codes": strings.Join(totpEmergency, ";"),
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create the TOTP sync entry: %w", err)
+	}
+
+	if err = repl.Save(db); err != nil {
+		return fmt.Errorf("unable to persist the TOTP sync entry: %w", err)
+	}
+
+	return nil
 }
 
 func GetNextReplicationEntryToPush(db *gorm.DB) (entry Replication, err error) {

--- a/internal/models/replication_test.go
+++ b/internal/models/replication_test.go
@@ -1,0 +1,84 @@
+package models
+
+import (
+	"os"
+	osuser "os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// totpSyncUser builds a hermetic user whose home is a throwaway directory,
+// optionally seeded with a ~/.google_authenticator file.
+func totpSyncUser(t *testing.T, totpFileContent string) *User {
+	t.Helper()
+	home := t.TempDir()
+	if totpFileContent != "" {
+		require.NoError(t,
+			os.WriteFile(filepath.Join(home, ".google_authenticator"), []byte(totpFileContent), 0600),
+			"failed to write the TOTP fixture")
+	}
+	return &User{User: &osuser.User{Username: "alice", HomeDir: home}}
+}
+
+// TestSyncTOTPState pins the outbox snapshot the front-end queues on every
+// invocation of a TOTP-enabled user: the persisted action string is part of
+// the replication name contract, and the payload must round-trip into the
+// exact state the peer's Replicate handler will write.
+func TestSyncTOTPState(t *testing.T) {
+
+	t.Run("TOTP-enabled user queues a snapshot of the current state", func(t *testing.T) {
+		user := totpSyncUser(t, "SECRETBASE32\n\" RATE_LIMIT 3 30\n11111111\n22222222\n")
+		dbPath := filepath.Join(t.TempDir(), "replication.db")
+
+		require.NoError(t, SyncTOTPState(user, dbPath))
+
+		db, err := GetReplicationGormDB(dbPath)
+		require.NoError(t, err)
+		var entries []Replication
+		require.NoError(t, db.Find(&entries).Error)
+		require.Len(t, entries, 1, "exactly one outbox entry must be queued")
+		require.Equal(t, "self totp emergency-codes generate", entries[0].Action,
+			"the action string is a persisted replication contract")
+
+		data, err := DecryptReplicationData(entries[0].Data)
+		require.NoError(t, err)
+		require.Equal(t, "alice", data["account"])
+		require.Equal(t, "SECRETBASE32", data["secret"])
+		require.Equal(t, "11111111;22222222", data["random-codes"])
+	})
+
+	t.Run("user without TOTP is a successful no-op", func(t *testing.T) {
+		user := totpSyncUser(t, "")
+		dbPath := filepath.Join(t.TempDir(), "replication.db")
+
+		require.NoError(t, SyncTOTPState(user, dbPath))
+
+		_, err := os.Stat(dbPath)
+		require.True(t, os.IsNotExist(err), "the outbox must not even be opened when there is nothing to sync")
+	})
+
+	t.Run("malformed TOTP file is an error and queues nothing", func(t *testing.T) {
+		// An empty file means "TOTP half-configured": GetTOTP refuses to
+		// treat it as either enabled or disabled, and the sync must surface
+		// that rather than publish a bogus snapshot to peers.
+		user := totpSyncUser(t, "\n\n")
+		dbPath := filepath.Join(t.TempDir(), "replication.db")
+
+		err := SyncTOTPState(user, dbPath)
+		require.ErrorContains(t, err, "unable to read TOTP state")
+
+		_, statErr := os.Stat(dbPath)
+		require.True(t, os.IsNotExist(statErr), "no outbox entry may be queued from an unreadable state")
+	})
+
+	t.Run("unavailable outbox database is an error", func(t *testing.T) {
+		user := totpSyncUser(t, "SECRETBASE32\n11111111\n")
+
+		// A directory is never a valid SQLite file, so opening it fails the
+		// same way a corrupt or locked outbox would.
+		err := SyncTOTPState(user, t.TempDir())
+		require.ErrorContains(t, err, "unable to open the replication outbox")
+	})
+}

--- a/main.go
+++ b/main.go
@@ -29,51 +29,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	// If replication is enabled
+	// On replicated setups, snapshot the user's TOTP state into the
+	// replication outbox so a recovery code consumed by PAM during this very
+	// authentication gets invalidated on the peer instances too. Deliberately
+	// best-effort: a failed sync warns loudly but never blocks the session —
+	// it retries on the user's next invocation, and failing closed here would
+	// lock every TOTP user out of the bastion on any outbox hiccup. (The
+	// historical inline version aborted the whole invocation, partly with
+	// exit code 0.)
 	if config.GetReplicationEnabled() {
-
-		totpEnabled, secret, totpEmergency, totpErr := currentUser.GetTOTP()
-
-		// A corrupt or unreadable TOTP file must not abort every command this user
-		// runs: warn and skip the recovery-code replication sync rather than
-		// failing the whole invocation.
-		if totpErr != nil {
-			fmt.Printf("warning: unable to read TOTP state, skipping replication sync: %s\n", totpErr)
-		} else if totpEnabled {
-
-			// Maybe the user used a recovery code, and we need to sync it to the other instances
-			dbHandler, err := models.GetReplicationGormDB(config.GetReplicationDatabasePath())
-			if err != nil {
-				fmt.Printf("unable to init replication db handle: %s\n", err)
-				return
-			}
-			sqlDB, err := dbHandler.DB()
-			if err != nil {
-				fmt.Printf("unable to init replication db handle: %s\n", err)
-				return
-			}
-
-			replicationData := models.ReplicationData{
-				"account":      currentUser.User.Username,
-				"secret":       secret,
-				"random-codes": strings.Join(totpEmergency, ";"),
-			}
-			repl, err := models.NewReplicationEntry("self totp emergency-codes generate", replicationData)
-			if err != nil {
-				fmt.Printf("unable to handle create replication entry: %s\n", err)
-				return
-			}
-			err = repl.Save(dbHandler)
-			if err != nil {
-				sqlDB.Close()
-				fmt.Printf("unable to save replication entry: %s\n", err)
-				os.Exit(1)
-			}
-
-			sqlDB.Close()
-
+		if err := models.SyncTOTPState(currentUser, config.GetReplicationDatabasePath()); err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: unable to sync TOTP state to the replication outbox, peer instances may be stale: %s\n", err)
 		}
-
 	}
 
 	// Parse the command line


### PR DESCRIPTION
## Summary

The ~45-line inline block at the top of `main()` — which, on replicated setups, snapshots the calling user's TOTP state into the replication outbox on every invocation — now lives as `models.SyncTOTPState`, fully documented and tested, with one deliberate behavior fix: a failed sync **warns loudly and lets the session proceed** instead of silently killing it.

## Background (what this block is)

Emergency/scratch codes are consumed by `pam_google_authenticator` during SSH authentication — before sb runs and without any event sb could observe. The only way to invalidate a used code on peer instances is to re-publish the user's current `~/.google_authenticator` content, so the front-end does it pessimistically on every invocation; peers apply the snapshot through the existing `self totp emergency-codes generate` Replicate handler (a no-op overwrite when nothing changed).

## Previous behavior

The block lived inline in `main()` with zero test coverage and inconsistent error handling: an unreadable TOTP file warned and continued, but an unavailable outbox DB or a failed entry creation **silently aborted the whole invocation with exit code 0** (the user's command never ran, while looking successful to scripts), and a failed save exited 1.

## Why it was a problem

`main` hosted untestable replication logic, and on a replicated setup a locked/corrupt outbox database bricked every TOTP user's login — partly with a success exit code.

## What changed

- New `models.SyncTOTPState(user, dbPath) error` next to the rest of the replication code; the action string (a persisted replication-name contract) and payload shape are unchanged.
- `main()` shrinks to a guarded 4-line call with one explicit policy: **best-effort**. Any sync failure prints a `WARNING:` to stderr ("peer instances may be stale") and the session continues — the snapshot retries on the next invocation, and failing closed would lock every TOTP user out of the bastion on any outbox hiccup. This matches the existing project stance that login-path checks never block the shell (only the daemon fails closed).

## How it's tested

Hermetic table tests (throwaway home dirs, file-based SQLite in temp dirs): the queued snapshot carries the contract action string and the payload round-trips to the exact state (account/secret/codes); a user without TOTP is a no-op that never opens the outbox; a malformed TOTP file errors without queueing; an unavailable outbox errors. `go build ./...`, `go test ./...`, `golangci-lint run` green; demo-stack e2e suite passes against this branch.

## Test plan

- [ ] `go test ./internal/models/ -run TestSyncTOTPState -v`
- [ ] `tests/e2e-local.sh`