### PR TITLE
models: hoist the duplicated egress access dedup out of ttyrec and scp

### DIFF
--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -245,29 +245,14 @@ func (c *Scp) Replicate(repl models.ReplicationData) (err error) {
 	return
 }
 
+// getUniqueAccessFromAvailableAccesses resolves the user's input to exactly
+// one connection target. The deduplication itself lives in
+// models.UniqueAccessesForHost; the SCP-specific policy is that an ambiguous
+// target is refused — the transfer runs under the wrapper script with no
+// terminal to prompt the user on (unlike ttyrec, which asks interactively).
 func (c *Scp) getUniqueAccessFromAvailableAccesses(accesses []*models.Access, host string) (a *models.Access, err error) {
 
-	// We initialize with the first access returned
-	uniqueAccesses := make([]*models.Access, 0)
-
-	for i := 0; i < len(accesses); i++ {
-		unique := true
-
-		// In case of a wide prefix stored access, we replace the Host by the user input
-		if accesses[i].Host == "" {
-			accesses[i].Host = host
-		}
-
-		for _, ua := range uniqueAccesses {
-			if accesses[i].Equals(ua) {
-				unique = false
-			}
-		}
-
-		if unique {
-			uniqueAccesses = append(uniqueAccesses, accesses[i])
-		}
-	}
+	uniqueAccesses := models.UniqueAccessesForHost(accesses, host)
 
 	if len(uniqueAccesses) == 1 {
 		return uniqueAccesses[0], nil

--- a/cmd/ttyrec.go
+++ b/cmd/ttyrec.go
@@ -419,29 +419,14 @@ func (c *Ttyrec) displayMatchingGrants(sources []*models.Source) {
 	fmt.Printf("Access to this host is granted by:\n%s\n", strings.Join(sourcesDisplay, "\n"))
 }
 
+// getUniqueAccessFromAvailableAccesses resolves the user's input to exactly
+// one connection target. The deduplication itself lives in
+// models.UniqueAccessesForHost; the ttyrec-specific policy is that an
+// ambiguous target prompts the user interactively (unlike scp, which has no
+// terminal to prompt on and refuses).
 func (c *Ttyrec) getUniqueAccessFromAvailableAccesses(accesses []*models.Access, host string) (a *models.Access, err error) {
 
-	// We initialize with the first access returned
-	uniqueAccesses := make([]*models.Access, 0)
-
-	for i := 0; i < len(accesses); i++ {
-		unique := true
-
-		// In case of a wide prefix stored access, we replace the Host by the user input
-		if accesses[i].Host == "" {
-			accesses[i].Host = host
-		}
-
-		for _, ua := range uniqueAccesses {
-			if accesses[i].Equals(ua) {
-				unique = false
-			}
-		}
-
-		if unique {
-			uniqueAccesses = append(uniqueAccesses, accesses[i])
-		}
-	}
+	uniqueAccesses := models.UniqueAccessesForHost(accesses, host)
 
 	if len(uniqueAccesses) == 1 {
 		return uniqueAccesses[0], nil

--- a/internal/models/access.go
+++ b/internal/models/access.go
@@ -278,6 +278,45 @@ func (ba *Access) Save(db *gorm.DB) (err error) {
 	return db.Save(ba).Error
 }
 
+// UniqueAccessesForHost deduplicates the accesses matched for a connection
+// target, returning them in their original order with duplicates (same
+// host/user/port triple, per Equals) removed. Accesses granted on a wide
+// prefix are stored without a Host; those are completed in place with the
+// host the user actually typed, both so deduplication compares real targets
+// and so the caller connects to the requested host rather than an empty one.
+//
+// The egress commands (ttyrec, scp) call this to decide whether the user's
+// input resolves to exactly one connection target; what to do with several
+// remains the caller's policy (ttyrec prompts interactively, scp refuses —
+// its wrapper has no terminal to prompt on).
+func UniqueAccessesForHost(accesses []*Access, host string) []*Access {
+
+	uniqueAccesses := make([]*Access, 0, len(accesses))
+
+	for _, access := range accesses {
+
+		// A wide-prefix access carries no host of its own: the target is
+		// whatever host the user typed (which BuildSBAccess already matched
+		// against the prefix).
+		if access.Host == "" {
+			access.Host = host
+		}
+
+		unique := true
+		for _, ua := range uniqueAccesses {
+			if access.Equals(ua) {
+				unique = false
+				break
+			}
+		}
+		if unique {
+			uniqueAccesses = append(uniqueAccesses, access)
+		}
+	}
+
+	return uniqueAccesses
+}
+
 // String returns a pretty print display of the access
 func (ba *Access) String() string {
 	green := color.New(color.FgGreen).SprintFunc()

--- a/internal/models/access_test.go
+++ b/internal/models/access_test.go
@@ -472,6 +472,54 @@ func TestIsIPv4(t *testing.T) {
 
 }
 
+// TestUniqueAccessesForHost pins the dedup behavior the egress commands
+// (ttyrec, scp) rely on to decide whether the user's input names exactly one
+// connection target.
+func TestUniqueAccessesForHost(t *testing.T) {
+
+	t.Run("duplicates collapse, order is preserved", func(t *testing.T) {
+		a1 := &Access{Host: "h1", User: "root", Port: 22}
+		a2 := &Access{Host: "h2", User: "root", Port: 22}
+		dup := &Access{Host: "h1", User: "root", Port: 22}
+
+		unique := UniqueAccessesForHost([]*Access{a1, a2, dup}, "typed.example.com")
+		require.Equal(t, []*Access{a1, a2}, unique)
+	})
+
+	t.Run("same host with different user or port stays distinct", func(t *testing.T) {
+		a1 := &Access{Host: "h1", User: "root", Port: 22}
+		a2 := &Access{Host: "h1", User: "app", Port: 22}
+		a3 := &Access{Host: "h1", User: "root", Port: 2222}
+
+		unique := UniqueAccessesForHost([]*Access{a1, a2, a3}, "h1")
+		require.Len(t, unique, 3)
+	})
+
+	t.Run("wide-prefix accesses take the typed host", func(t *testing.T) {
+		// An access granted on a prefix is stored without a host; the typed
+		// host completes it, and that completion participates in dedup: two
+		// prefix grants for the same user/port collapse once completed.
+		p1 := &Access{Host: "", User: "root", Port: 22}
+		p2 := &Access{Host: "", User: "root", Port: 22}
+
+		unique := UniqueAccessesForHost([]*Access{p1, p2}, "10.0.0.7")
+		require.Len(t, unique, 1)
+		require.Equal(t, "10.0.0.7", unique[0].Host, "the typed host must complete the wide-prefix access")
+	})
+
+	t.Run("completed prefix access deduplicates against an explicit grant", func(t *testing.T) {
+		explicit := &Access{Host: "10.0.0.7", User: "root", Port: 22}
+		prefix := &Access{Host: "", User: "root", Port: 22}
+
+		unique := UniqueAccessesForHost([]*Access{explicit, prefix}, "10.0.0.7")
+		require.Equal(t, []*Access{explicit}, unique)
+	})
+
+	t.Run("empty input yields an empty result", func(t *testing.T) {
+		require.Empty(t, UniqueAccessesForHost(nil, "h1"))
+	})
+}
+
 type testBuildSBAccessFromUserInput struct {
 	e testSplitUserInputInputData
 	o testBuildSBAccessOutputData


### PR DESCRIPTION
## Summary

`getUniqueAccessFromAvailableAccesses` existed twice — verbatim-identical dedup loops in `cmd/ttyrec.go` and `cmd/scp.go` — differing only in what happens on an ambiguous target. The shared logic now lives once as `models.UniqueAccessesForHost`, tested; the commands keep only their policy tails. No behavior change.

## Previous behavior

Both commands carried their own copy of the loop that collapses accesses with the same host/user/port and completes wide-prefix grants (stored with an empty host) with the host the user typed.

## Why it was a problem

The shared logic had no tests, and a fix to one copy could silently miss the other — the classic drift risk of duplicated security-adjacent code on the egress path.

## What changed

- New `models.UniqueAccessesForHost(accesses, host)`: order-preserving dedup plus in-place wide-prefix host completion, with the rationale documented (the completion participates in dedup, so a prefix grant collapses against an explicit grant for the same target).
- `ttyrec` and `scp` keep thin wrappers holding only their policy: single match → use it; several → ttyrec prompts the user interactively, scp refuses with its historical message (its wrapper has no terminal to prompt on).

## How it's tested

Table tests pin the hoisted function: duplicate collapse with order preserved, distinctness by user and port, wide-prefix completion with the typed host, a completed prefix deduplicating against an explicit grant, and empty input. `go build ./...`, `go test ./...`, `golangci-lint run` green; demo-stack e2e passes against this branch (host connections and SCP exercise both wrappers end to end).

## Test plan

- [ ] `go test ./internal/models/ -run TestUniqueAccessesForHost -v`
- [ ] `tests/e2e-local.sh`